### PR TITLE
Feat#9: 판매글 카드 컴포넌트 UI 구현

### DIFF
--- a/src/shared/constants/category.json
+++ b/src/shared/constants/category.json
@@ -1,0 +1,302 @@
+[
+  {
+    "id": 1,
+    "name": "경제/경영",
+    "parent_id": null
+  },
+  {
+    "id": 2,
+    "name": "과학/IT",
+    "parent_id": null
+  },
+  {
+    "id": 3,
+    "name": "만화",
+    "parent_id": null
+  },
+  {
+    "id": 4,
+    "name": "문학",
+    "parent_id": null
+  },
+  {
+    "id": 5,
+    "name": "어린이/청소년",
+    "parent_id": null
+  },
+  {
+    "id": 6,
+    "name": "예술/문화",
+    "parent_id": null
+  },
+  {
+    "id": 7,
+    "name": "인문/사회",
+    "parent_id": null
+  },
+  {
+    "id": 8,
+    "name": "자기계발",
+    "parent_id": null
+  },
+  {
+    "id": 9,
+    "name": "취미/실용",
+    "parent_id": null
+  },
+  {
+    "id": 10,
+    "name": "학습/수험",
+    "parent_id": null
+  },
+  {
+    "id": 11,
+    "name": "기타",
+    "parent_id": null
+  },
+  {
+    "id": 12,
+    "name": "경영일반",
+    "parent_id": 1
+  },
+  {
+    "id": 13,
+    "name": "마케팅/세일즈",
+    "parent_id": 1
+  },
+  {
+    "id": 14,
+    "name": "재테크",
+    "parent_id": 1
+  },
+  {
+    "id": 15,
+    "name": "창업",
+    "parent_id": 1
+  },
+  {
+    "id": 16,
+    "name": "회계/재무",
+    "parent_id": 1
+  },
+  {
+    "id": 17,
+    "name": "공학일반",
+    "parent_id": 2
+  },
+  {
+    "id": 18,
+    "name": "수학",
+    "parent_id": 2
+  },
+  {
+    "id": 19,
+    "name": "자연과학",
+    "parent_id": 2
+  },
+  {
+    "id": 20,
+    "name": "컴퓨터공학",
+    "parent_id": 2
+  },
+  {
+    "id": 21,
+    "name": "프로그래밍",
+    "parent_id": 2
+  },
+  {
+    "id": 22,
+    "name": "그래픽노블",
+    "parent_id": 3
+  },
+  {
+    "id": 23,
+    "name": "웹툰",
+    "parent_id": 3
+  },
+  {
+    "id": 24,
+    "name": "일본만화",
+    "parent_id": 3
+  },
+  {
+    "id": 25,
+    "name": "한국만화",
+    "parent_id": 3
+  },
+  {
+    "id": 26,
+    "name": "시/희곡",
+    "parent_id": 4
+  },
+  {
+    "id": 27,
+    "name": "에세이",
+    "parent_id": 4
+  },
+  {
+    "id": 28,
+    "name": "외국소설",
+    "parent_id": 4
+  },
+  {
+    "id": 29,
+    "name": "한국소설",
+    "parent_id": 4
+  },
+  {
+    "id": 30,
+    "name": "동화책",
+    "parent_id": 5
+  },
+  {
+    "id": 31,
+    "name": "유아그림책",
+    "parent_id": 5
+  },
+  {
+    "id": 32,
+    "name": "청소년 문학",
+    "parent_id": 5
+  },
+  {
+    "id": 33,
+    "name": "학습만화",
+    "parent_id": 5
+  },
+  {
+    "id": 34,
+    "name": "미술/디자인",
+    "parent_id": 6
+  },
+  {
+    "id": 35,
+    "name": "사진",
+    "parent_id": 6
+  },
+  {
+    "id": 36,
+    "name": "영화/연극",
+    "parent_id": 6
+  },
+  {
+    "id": 37,
+    "name": "음악/악보",
+    "parent_id": 6
+  },
+  {
+    "id": 38,
+    "name": "사회학",
+    "parent_id": 7
+  },
+  {
+    "id": 39,
+    "name": "심리학",
+    "parent_id": 7
+  },
+  {
+    "id": 40,
+    "name": "역사",
+    "parent_id": 7
+  },
+  {
+    "id": 41,
+    "name": "정치/법",
+    "parent_id": 7
+  },
+  {
+    "id": 42,
+    "name": "철학",
+    "parent_id": 7
+  },
+  {
+    "id": 43,
+    "name": "리더십",
+    "parent_id": 8
+  },
+  {
+    "id": 44,
+    "name": "성공/동기부여",
+    "parent_id": 8
+  },
+  {
+    "id": 45,
+    "name": "습관",
+    "parent_id": 8
+  },
+  {
+    "id": 46,
+    "name": "시간관리",
+    "parent_id": 8
+  },
+  {
+    "id": 47,
+    "name": "인간관계",
+    "parent_id": 8
+  },
+  {
+    "id": 48,
+    "name": "건강",
+    "parent_id": 9
+  },
+  {
+    "id": 49,
+    "name": "여행",
+    "parent_id": 9
+  },
+  {
+    "id": 50,
+    "name": "요리",
+    "parent_id": 9
+  },
+  {
+    "id": 51,
+    "name": "육아",
+    "parent_id": 9
+  },
+  {
+    "id": 52,
+    "name": "인테리어",
+    "parent_id": 9
+  },
+  {
+    "id": 53,
+    "name": "공무원/수험서",
+    "parent_id": 10
+  },
+  {
+    "id": 54,
+    "name": "대학교재",
+    "parent_id": 10
+  },
+  {
+    "id": 55,
+    "name": "문제집",
+    "parent_id": 10
+  },
+  {
+    "id": 56,
+    "name": "자격증",
+    "parent_id": 10
+  },
+  {
+    "id": 57,
+    "name": "초·중·고 참고서",
+    "parent_id": 10
+  },
+  {
+    "id": 58,
+    "name": "기타도서",
+    "parent_id": 11
+  },
+  {
+    "id": 59,
+    "name": "잡지",
+    "parent_id": 11
+  },
+  {
+    "id": 60,
+    "name": "정기간행물",
+    "parent_id": 11
+  }
+]

--- a/src/shared/lib/getCategoryNameById.ts
+++ b/src/shared/lib/getCategoryNameById.ts
@@ -1,0 +1,11 @@
+import categories from '@/shared/constants/category.json';
+
+type Category = {
+  id: number;
+  name: string;
+  parent_id: number | null;
+};
+
+export function getCategoryNameById(id: number): string | undefined {
+  return categories.find((cat: Category) => cat.id === id)?.name;
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,5 @@
+import { getCategoryNameById } from './getCategoryNameById';
+import { withIconSize } from './withIconSize';
+import { tradeStatusMap, bookStatusMap } from './postTextMap';
+
+export { getCategoryNameById, withIconSize, tradeStatusMap, bookStatusMap };

--- a/src/shared/lib/postTextMap.ts
+++ b/src/shared/lib/postTextMap.ts
@@ -1,0 +1,12 @@
+export const tradeStatusMap = {
+  READY: '거래 대기',
+  IN_PROGRESS: '거래 중',
+  COMPLETED: '거래 완료',
+} as const;
+
+export const bookStatusMap = {
+  BEST: '최상',
+  HIGH: '상',
+  MEDIUM: '중',
+  LOW: '하',
+} as const;

--- a/src/shared/ui/ListingCard.styles.ts
+++ b/src/shared/ui/ListingCard.styles.ts
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+import { colors } from '../constants';
+
+interface OverlayProps {
+  status: 'READY' | 'IN_PROGRESS' | 'COMPLETED';
+}
+
+export const CardContainer = styled.div`
+  width: 25%;
+  padding: 10px;
+  cursor: pointer;
+  &:hover img {
+    transform: scale(1.1);
+  }
+
+  @media (max-width: 1024px) {
+    width: 35%;
+  }
+
+  @media (max-width: 744px) {
+    width: 45%;
+  }
+`;
+
+export const ImageWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  overflow: hidden;
+  border-radius: 10px;
+`;
+
+export const Overlay = styled.div<OverlayProps>`
+  background-color: ${({ status }) =>
+    status === 'READY' ? 'transparent' : 'rgba(0, 0, 0, 0.7)'};
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+  border-radius: 10px;
+  border: 0.5px solid ${colors.light.GRAY_600};
+`;
+
+export const Image = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.03);
+  transform-origin: center;
+  transition: transform 0.3s ease;
+`;
+
+export const TagWrapper = styled.div`
+  position: absolute;
+  top: 5px;
+  right: 10px;
+`;
+
+export const OverlayStatusText = styled.div`
+  font-size: 20px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+export const TitleText = styled.p`
+  margin-top: 10px;
+  margin-bottom: 5px;
+  font-size: 16px;
+  font-weight: 500;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  @media (max-width: 480px) {
+    font-size: 14px;
+  }
+`;
+
+export const PriceText = styled.span`
+  font-size: 16px;
+  font-weight: 700;
+
+  @media (max-width: 480px) {
+    font-size: 14px;
+  }
+`;
+
+export const InfoWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/src/shared/ui/ListingCard.styles.ts
+++ b/src/shared/ui/ListingCard.styles.ts
@@ -28,17 +28,44 @@ export const ImageWrapper = styled.div`
   padding-bottom: 100%;
   overflow: hidden;
   border-radius: 10px;
+  border: 0.5px solid ${colors.light.GRAY_600};
 `;
 
-export const Overlay = styled.div<OverlayProps>`
-  background-color: ${({ status }) =>
-    status === 'READY' ? 'transparent' : 'rgba(0, 0, 0, 0.7)'};
+export const Overlay = styled.div`
   position: absolute;
   width: 100%;
   height: 100%;
   z-index: 10;
   border-radius: 10px;
-  border: 0.5px solid ${colors.light.GRAY_600};
+`;
+
+export const OverlayDim = styled.div<OverlayProps>`
+  position: absolute;
+  background-color: ${({ status }) =>
+    status === 'READY' ? 'transparent' : 'rgba(0, 0, 0, 0.7)'};
+  z-index: 11;
+  width: 100%;
+  height: 100%;
+`;
+
+export const TagWrapper = styled.div`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+`;
+
+export const OverlayStatusText = styled.div`
+  position: absolute;
+  font-size: 20px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: ${colors.light.WHITE};
+  z-index: 13;
 `;
 
 export const Image = styled.img`
@@ -49,21 +76,6 @@ export const Image = styled.img`
   transform: scale(1.03);
   transform-origin: center;
   transition: transform 0.3s ease;
-`;
-
-export const TagWrapper = styled.div`
-  position: absolute;
-  top: 5px;
-  right: 10px;
-`;
-
-export const OverlayStatusText = styled.div`
-  font-size: 20px;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
 `;
 
 export const TitleText = styled.p`

--- a/src/shared/ui/ListingCard.tsx
+++ b/src/shared/ui/ListingCard.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import ListingCardTag from './ListingCardTag';
+import { bookStatusMap, getCategoryNameById, tradeStatusMap } from '../lib';
+import * as S from './ListingCard.styles';
+
+interface ListingCardProps {
+  postId: number;
+  categoryId: number;
+  title: string;
+  tradeStatus: 'READY' | 'IN_PROGRESS' | 'COMPLETED';
+  sellPrice: number;
+  thumbnail: string;
+  bookStatus: 'BEST' | 'HIGH' | 'MEDIUM' | 'LOW';
+  createdAt: string;
+}
+
+const data: ListingCardProps = {
+  postId: 1,
+  categoryId: 10,
+  title: '자바 성능 튜닝 이야기 - 개발자가 반드시 알아야 할',
+  tradeStatus: 'IN_PROGRESS',
+  sellPrice: 8000,
+  thumbnail:
+    'https://image.aladin.co.kr/product/7924/83/coversum/k542434036_1.jpg',
+  bookStatus: 'BEST',
+  createdAt: '2024-03-29T10:22:00',
+};
+
+const ListingCard = () => {
+  const categoryName = getCategoryNameById(data.categoryId);
+
+  return (
+    <S.CardContainer>
+      <S.ImageWrapper>
+        <S.Overlay status={data.tradeStatus}>
+          {data.tradeStatus === 'READY' ? (
+            <S.TagWrapper>
+              <ListingCardTag
+                text={bookStatusMap[data.bookStatus]}
+                type='STATUS'
+              />
+            </S.TagWrapper>
+          ) : (
+            <S.OverlayStatusText>
+              {tradeStatusMap[data.tradeStatus]}
+            </S.OverlayStatusText>
+          )}
+        </S.Overlay>
+        <S.Image src={data.thumbnail} />
+      </S.ImageWrapper>
+      <S.TitleText>{data.title}</S.TitleText>
+      <S.InfoWrapper>
+        <S.PriceText>{data.sellPrice.toLocaleString('ko-KR')}원</S.PriceText>
+        <ListingCardTag
+          text={categoryName ? categoryName : '찾을 수 없음'}
+          type='CATEGORY'
+        />
+      </S.InfoWrapper>
+    </S.CardContainer>
+  );
+};
+
+export default ListingCard;

--- a/src/shared/ui/ListingCard.tsx
+++ b/src/shared/ui/ListingCard.tsx
@@ -19,7 +19,7 @@ const data: ListingCardProps = {
   postId: 1,
   categoryId: 10,
   title: '자바 성능 튜닝 이야기 - 개발자가 반드시 알아야 할',
-  tradeStatus: 'IN_PROGRESS',
+  tradeStatus: 'READY',
   sellPrice: 8000,
   thumbnail:
     'https://image.aladin.co.kr/product/7924/83/coversum/k542434036_1.jpg',
@@ -33,19 +33,19 @@ const ListingCard = () => {
   return (
     <S.CardContainer>
       <S.ImageWrapper>
-        <S.Overlay status={data.tradeStatus}>
-          {data.tradeStatus === 'READY' ? (
-            <S.TagWrapper>
-              <ListingCardTag
-                text={bookStatusMap[data.bookStatus]}
-                type='STATUS'
-              />
-            </S.TagWrapper>
-          ) : (
+        <S.Overlay>
+          <S.OverlayDim status={data.tradeStatus} />
+          {data.tradeStatus !== 'READY' && (
             <S.OverlayStatusText>
               {tradeStatusMap[data.tradeStatus]}
             </S.OverlayStatusText>
           )}
+          <S.TagWrapper>
+            <ListingCardTag
+              text={bookStatusMap[data.bookStatus]}
+              type='STATUS'
+            />
+          </S.TagWrapper>
         </S.Overlay>
         <S.Image src={data.thumbnail} />
       </S.ImageWrapper>

--- a/src/shared/ui/ListingCardTag.tsx
+++ b/src/shared/ui/ListingCardTag.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { colors } from '../constants';
+
+const ListingCardTag = ({
+  text,
+  type,
+}: {
+  text: string;
+  type: 'CATEGORY' | 'STATUS';
+}) => {
+  return <Container type={type}>#{text}</Container>;
+};
+
+export default ListingCardTag;
+
+interface TagProps {
+  type: 'CATEGORY' | 'STATUS';
+}
+const Container = styled.div<TagProps>`
+  background-color: ${({ type }) =>
+    type === 'CATEGORY' ? colors.light.SECONDARY : colors.light.PRIMARY};
+  padding: 3px 5px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: ${colors.light.WHITE};
+  @media (max-width: 480px) {
+    font-size: 10px;
+  }
+`;

--- a/src/shared/ui/ListingList.tsx
+++ b/src/shared/ui/ListingList.tsx
@@ -1,12 +1,17 @@
 'use client';
 import styled from 'styled-components';
+import ListingCard from './ListingCard';
 
 const ListingList = () => {
-  return <Container>판매글 리스트</Container>;
+  return (
+    <Container>
+      판매글 리스트
+      <ListingCard />
+    </Container>
+  );
 };
 
 export default ListingList;
 export const Container = styled.div`
   flex: 1;
-  background-color: pink;
 `;


### PR DESCRIPTION
### #️⃣연관된 이슈
> #9 

### 📜 작업 내용
> - [x] category.json 파일 추가
> - [x] 카테고리 id로 이름 반환하는 함수 및 책, 거래 상태 매핑 객체 추가
> - [x] 판매글 카드 UI 컴포넌트 구현
> - [x] hover 시 이미지 확대

### 🖼️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/c55c14e6-ca75-47a0-ae58-1ba0c25eb983" width=200/>
<img src="https://github.com/user-attachments/assets/401b3dcb-1732-4f0d-bfa3-1dcc5fc07ad4" width=200/>

### 📄 참고 링크 (선택)

### ⚠️ 종료할 이슈
this closes #9 
