### PR TITLE
Feat#21: 판매글 리스트 정렬 드롭다운 UI 구현

### DIFF
--- a/src/entities/listing/model/types.ts
+++ b/src/entities/listing/model/types.ts
@@ -1,5 +1,6 @@
 export type BookStatus = 'BEST' | 'HIGH' | 'MEDIUM' | 'LOW';
 export type TradeStatus = 'READY' | 'IN_PROGRESS' | 'COMPLETED';
+export type SortKey = 'RECENT' | 'OLD' | 'LOW_PRICE' | 'HIGH_PRICE';
 
 export interface ListingCardProps {
   postId: number;

--- a/src/features/listing/model/useFilterStore.ts
+++ b/src/features/listing/model/useFilterStore.ts
@@ -1,4 +1,4 @@
-import { BookStatus } from '@/entities/listing/model/types';
+import { BookStatus, SortKey } from '@/entities/listing/model/types';
 import { create } from 'zustand';
 
 type FilterState = {
@@ -7,12 +7,14 @@ type FilterState = {
   categoryId: number | null;
   bookStatus: BookStatus | null;
   priceRange: number | null;
+  sort: SortKey;
   setEmdId: (e: number | null) => void;
   setIsAvailableOnly: (b: boolean) => void;
   toggleIsAvailableOnly: () => void;
   setCategoryId: (c: number | null) => void;
   setBookStatus: (b: BookStatus | null) => void;
   setPriceRange: (p: number | null) => void;
+  setSort: (s: SortKey) => void;
   resetFilters: () => void;
 };
 
@@ -22,6 +24,7 @@ export const useFilterStore = create<FilterState>((set) => ({
   categoryId: null,
   bookStatus: null,
   priceRange: null,
+  sort: 'RECENT',
   setEmdId: (e) => set({ emdId: e }),
   setIsAvailableOnly: (b) => set({ isAvailableOnly: b }),
   toggleIsAvailableOnly: () =>
@@ -29,6 +32,7 @@ export const useFilterStore = create<FilterState>((set) => ({
   setCategoryId: (c) => set({ categoryId: c }),
   setBookStatus: (b) => set({ bookStatus: b }),
   setPriceRange: (p) => set({ priceRange: p }),
+  setSort: (s) => set({ sort: s }),
   resetFilters: () =>
     set({
       isAvailableOnly: false,

--- a/src/features/listing/ui/ListingSortDropdown.tsx
+++ b/src/features/listing/ui/ListingSortDropdown.tsx
@@ -26,7 +26,7 @@ const ListingSortDropdown = () => {
       <DropdownBox onClick={handleDropdownToggle}>
         <span>{sortMap[options.find((opt) => opt === sort) ?? 'RECENT']}</span>
 
-        <DropdownIconSm style={{ fill: theme.colors.BLACK }} />
+        <DropdownIconSm style={{ fill: theme.colors.GRAY_700 }} />
       </DropdownBox>
       {isOpen && (
         <DropdownList>
@@ -48,24 +48,21 @@ export default ListingSortDropdown;
 const Container = styled.div`
   position: relative;
   width: 100px;
-  height: 40px;
   display: flex;
   align-items: center;
-  justify-content: center;
+
   font-size: 14px;
+  color: ${({ theme }) => theme.colors.GRAY_700};
 `;
 
 const DropdownBox = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: end;
   font-weight: 500;
   width: 100%;
   gap: 5px;
   cursor: pointer;
-  padding: 5px 0 5px 5px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.GRAY_400};
 `;
 
 const DropdownList = styled.div`
@@ -87,7 +84,7 @@ const DropdownItem = styled.div<{ selected: boolean }>`
   margin: 5px;
   font-weight: ${({ selected }) => (selected ? 500 : 400)};
   color: ${({ selected, theme }) =>
-    selected ? theme.colors.BLACK : theme.colors.GRAY_500};
+    selected ? theme.colors.GRAY_700 : theme.colors.GRAY_500};
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.GRAY_300};

--- a/src/features/listing/ui/ListingSortDropdown.tsx
+++ b/src/features/listing/ui/ListingSortDropdown.tsx
@@ -1,14 +1,95 @@
 'use client';
 
-import styled from 'styled-components';
+import { SortKey } from '@/entities/listing/model/types';
+import { DropdownIconSm } from '@/shared/assets/icons';
+import { sortMap } from '@/shared/lib';
+import { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
+import { useFilterStore } from '../model';
+
+const options: SortKey[] = ['RECENT', 'OLD', 'LOW_PRICE', 'HIGH_PRICE'];
 
 const ListingSortDropdown = () => {
-  return <Container>정렬 자리</Container>;
+  const theme = useTheme();
+  const [isOpen, setIsOpen] = useState(false);
+  const sort = useFilterStore((state) => state.sort);
+  const { setSort } = useFilterStore();
+  function handleDropdownToggle() {
+    setIsOpen((prev) => !prev);
+  }
+  function handleDropdownOptionClick(value: SortKey) {
+    setSort(value);
+    setIsOpen(false);
+  }
+  return (
+    <Container>
+      <DropdownBox onClick={handleDropdownToggle}>
+        <span>{sortMap[options.find((opt) => opt === sort) ?? 'RECENT']}</span>
+
+        <DropdownIconSm style={{ fill: theme.colors.BLACK }} />
+      </DropdownBox>
+      {isOpen && (
+        <DropdownList>
+          {options.map((option) => (
+            <DropdownItem
+              key={option}
+              selected={option === sort}
+              onClick={() => handleDropdownOptionClick(option)}>
+              {sortMap[option]}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      )}
+    </Container>
+  );
 };
 export default ListingSortDropdown;
 
 const Container = styled.div`
+  position: relative;
   width: 100px;
   height: 40px;
-  background-color: skyblue;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+`;
+
+const DropdownBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  width: 100%;
+  gap: 5px;
+  cursor: pointer;
+  padding: 5px 0 5px 5px;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.GRAY_400};
+`;
+
+const DropdownList = styled.div`
+  position: absolute;
+  width: 100%;
+  top: 100%;
+  margin-top: 10px;
+  left: 0;
+  background-color: ${({ theme }) => theme.colors.WHITE};
+  border-radius: 10px;
+  box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+`;
+
+const DropdownItem = styled.div<{ selected: boolean }>`
+  padding: 5px;
+  cursor: pointer;
+  border-radius: 5px;
+  margin: 5px;
+  font-weight: ${({ selected }) => (selected ? 500 : 400)};
+  color: ${({ selected, theme }) =>
+    selected ? theme.colors.BLACK : theme.colors.GRAY_500};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.GRAY_300};
+  }
 `;

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,5 +1,10 @@
 import { withIconSize } from './withIconSize';
-import { tradeStatusMap, bookStatusMap, priceRangeMap } from './postTextMap';
+import {
+  tradeStatusMap,
+  bookStatusMap,
+  priceRangeMap,
+  sortMap,
+} from './postTextMap';
 import { convertDateToString } from './date';
 
 export {
@@ -7,5 +12,6 @@ export {
   tradeStatusMap,
   bookStatusMap,
   priceRangeMap,
+  sortMap,
   convertDateToString,
 };

--- a/src/shared/lib/postTextMap.ts
+++ b/src/shared/lib/postTextMap.ts
@@ -16,3 +16,10 @@ export const priceRangeMap: { [key: number]: string } = {
   1: '5,000원~10,000원',
   2: '10,000원~20,000원',
 } as const;
+
+export const sortMap = {
+  RECENT: '최신순',
+  OLD: '오래된순',
+  LOW_PRICE: '낮은가격순',
+  HIGH_PRICE: '높은가격순',
+} as const;


### PR DESCRIPTION
### #️⃣연관된 이슈
> #21 

### 📜 작업 내용
- [x] 판매글 리스트 정렬 드롭다운 UI 구현
- [x] 정렬값 zustand로 관리

### 🖼️ 스크린샷 (선택)

### 📄 참고 링크 (선택)

### ⚠️ 종료할 이슈
this closes #21
