### PR TITLE
Feat#20: 마이페이지 - 내 프로필 UI 구현

### DIFF
--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { My } from '@/features/user/ui';
+import styled from 'styled-components';
+
+const MyPage = () => {
+  return (
+    <Container>
+      <My />
+    </Container>
+  );
+};
+export default MyPage;
+
+const Container = styled.div`
+  margin-right: 100px;
+  @media (max-width: 744px) {
+    margin-right: 0;
+  }
+`;

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -62,4 +62,5 @@ const Container = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 20px;
+  max-width: 300px;
 `;

--- a/src/features/user/ui/EditArea.tsx
+++ b/src/features/user/ui/EditArea.tsx
@@ -23,12 +23,15 @@ const EditArea = () => {
   }
   return (
     <S.EditAreaContainer>
+      <div style={{ marginBottom: 10 }}>
+        <span style={{ fontWeight: 600 }}>활동 지역</span>
+        <S.InfoText>*{emdName} 인증됨 (2025.06.11)</S.InfoText>
+      </div>
       <SelectAreaSection
         ref={sectionRef}
         showEditButton={true}
         onClickEdit={handleEditArea}
       />
-      <S.InfoText>*{emdName} 인증됨 (2025.06.11)</S.InfoText>
     </S.EditAreaContainer>
   );
 };

--- a/src/features/user/ui/EditArea.tsx
+++ b/src/features/user/ui/EditArea.tsx
@@ -1,0 +1,36 @@
+import { useRef, useState } from 'react';
+import { AreaState } from '@/shared/ui/SelectAreaSection';
+import emd_areas from '@/shared/constants/emd_areas.json';
+import { SelectAreaSection } from '@/shared/ui';
+import * as S from './EditProfile.styles';
+
+const EditArea = () => {
+  const defaultEmdId = 309;
+  const emdName = emd_areas.find((area) => area.id === defaultEmdId)?.name;
+  const sectionRef = useRef<{ getSelection: () => AreaState }>(null);
+  const [emdId, setEmdId] = useState<number | undefined>();
+
+  function handleApply() {
+    const selection = sectionRef.current?.getSelection();
+
+    if (selection?.sidoId && selection?.siggId && selection?.emdId) {
+      setEmdId(selection.emdId);
+    }
+  }
+
+  function handleEditArea() {
+    handleApply();
+  }
+  return (
+    <S.EditAreaContainer>
+      <SelectAreaSection
+        ref={sectionRef}
+        showEditButton={true}
+        onClickEdit={handleEditArea}
+      />
+      <S.InfoText>*{emdName} 인증됨 (2025.06.11)</S.InfoText>
+    </S.EditAreaContainer>
+  );
+};
+
+export default EditArea;

--- a/src/features/user/ui/EditNickname.tsx
+++ b/src/features/user/ui/EditNickname.tsx
@@ -19,8 +19,7 @@ const EditNickname = () => {
   });
 
   const nickname = useWatch({ name: 'nickname', control });
-  const nicknameDisabled =
-    !nickname || errors.nickname || nickname === defaultNickname;
+  const disabled = !nickname || errors.nickname || nickname === defaultNickname;
   function handleEditNickname() {}
   return (
     <S.NicknameSection>
@@ -34,12 +33,12 @@ const EditNickname = () => {
           },
         ]}
         register={register}
-        errors={{ nickname: errors.nickname }}
+        errors={errors}
       />
       <S.ButtonWrapper>
         <Button
           text='수정'
-          variant={nicknameDisabled ? 'disabled' : 'primary'}
+          variant={disabled ? 'disabled' : 'primary'}
           onClick={handleEditNickname}
         />
       </S.ButtonWrapper>

--- a/src/features/user/ui/EditNickname.tsx
+++ b/src/features/user/ui/EditNickname.tsx
@@ -1,0 +1,50 @@
+import { useForm, useWatch } from 'react-hook-form';
+import * as S from './EditProfile.styles';
+import { Button, InputGroup } from '@/shared/ui';
+import { nicknameRule } from '@/shared/constants';
+interface EditNicknameValues {
+  nickname: string;
+}
+const EditNickname = () => {
+  const defaultNickname = '지지';
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useForm<EditNicknameValues>({
+    defaultValues: {
+      nickname: defaultNickname,
+    },
+    mode: 'onChange',
+  });
+
+  const nickname = useWatch({ name: 'nickname', control });
+  const nicknameDisabled =
+    !nickname || errors.nickname || nickname === defaultNickname;
+  function handleEditNickname() {}
+  return (
+    <S.NicknameSection>
+      <InputGroup
+        inputs={[
+          {
+            name: 'nickname',
+            placeholder: '별명',
+            type: 'text',
+            rules: nicknameRule,
+          },
+        ]}
+        register={register}
+        errors={{ nickname: errors.nickname }}
+      />
+      <S.ButtonWrapper>
+        <Button
+          text='수정'
+          variant={nicknameDisabled ? 'disabled' : 'primary'}
+          onClick={handleEditNickname}
+        />
+      </S.ButtonWrapper>
+    </S.NicknameSection>
+  );
+};
+
+export default EditNickname;

--- a/src/features/user/ui/EditPassword.tsx
+++ b/src/features/user/ui/EditPassword.tsx
@@ -1,0 +1,110 @@
+import { useForm, useWatch } from 'react-hook-form';
+import * as S from './EditProfile.styles';
+import { Button, InputGroup } from '@/shared/ui';
+import { passwordConfirmRule, passwordSignupRule } from '@/shared/constants';
+import { useState } from 'react';
+
+interface EditPasswordValues {
+  nowPwd: string;
+  password: string;
+  passwordConfirm: string;
+}
+const EditPassword = () => {
+  const {
+    register,
+    control,
+    getValues,
+    reset,
+    formState: { errors },
+  } = useForm<EditPasswordValues>({
+    mode: 'onChange',
+  });
+
+  const nowPwd = useWatch({ name: 'nowPwd', control });
+  const password = useWatch({ name: 'password', control });
+  const passwordConfirm = useWatch({ name: 'passwordConfirm', control });
+  const disabled =
+    !nowPwd || !password || !passwordConfirm || Object.keys(errors).length > 0;
+
+  const [isOpen, setIsOpen] = useState(false);
+  function handleClickEditPwd() {
+    setIsOpen((prev) => !prev);
+  }
+
+  function handleCancelEdit() {
+    reset();
+    setIsOpen(false);
+  }
+  function handleEditPassword() {}
+
+  return (
+    <div style={{ marginTop: 20 }}>
+      <div style={{ width: 150 }}>
+        <Button
+          text='비밀번호 재설정'
+          onClick={handleClickEditPwd}
+          variant='secondary'
+        />
+      </div>
+      {isOpen && (
+        <div
+          style={{
+            marginTop: 20,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 20,
+          }}>
+          <InputGroup
+            inputs={[
+              {
+                name: 'nowPwd',
+                placeholder: '현재 비밀번호',
+                type: 'password',
+              },
+            ]}
+            register={register}
+            errors={{ nowPwd: errors.nowPwd }}
+          />
+          <InputGroup
+            inputs={[
+              {
+                name: 'password',
+                placeholder: '새 비밀번호',
+                type: 'password',
+                rules: passwordSignupRule,
+              },
+              {
+                name: 'passwordConfirm',
+                placeholder: '비밀번호 확인',
+                type: 'password',
+                rules: passwordConfirmRule(getValues),
+              },
+            ]}
+            register={register}
+            errors={errors}
+          />
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              maxWidth: 300,
+              justifyContent: 'end',
+            }}>
+            <S.ButtonWrapper>
+              <Button text='취소' variant='cancel' onClick={handleCancelEdit} />
+            </S.ButtonWrapper>
+            <S.ButtonWrapper>
+              <Button
+                text='저장'
+                variant={disabled ? 'disabled' : 'primary'}
+                onClick={handleEditPassword}
+              />
+            </S.ButtonWrapper>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EditPassword;

--- a/src/features/user/ui/EditPassword.tsx
+++ b/src/features/user/ui/EditPassword.tsx
@@ -53,6 +53,7 @@ const EditPassword = () => {
             display: 'flex',
             flexDirection: 'column',
             gap: 20,
+            maxWidth: 450,
           }}>
           <InputGroup
             inputs={[
@@ -87,7 +88,7 @@ const EditPassword = () => {
             style={{
               display: 'flex',
               width: '100%',
-              maxWidth: 300,
+              maxWidth: 450,
               justifyContent: 'end',
             }}>
             <S.ButtonWrapper>

--- a/src/features/user/ui/EditProfile.styles.ts
+++ b/src/features/user/ui/EditProfile.styles.ts
@@ -2,15 +2,25 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   width: 100%;
+  max-width: 450px;
   margin-top: 50px;
   padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
 
   @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
-    margin: 0;
+    margin-top: 10px;
   }
 `;
+
+export const AccountButton = styled.div`
+  font-size: 14px;
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
 export const NicknameSection = styled.div`
-  margin-top: 10px;
   display: flex;
   gap: 10px;
   align-items: start;
@@ -22,20 +32,24 @@ export const ButtonWrapper = styled.div`
 `;
 
 export const EditAreaContainer = styled.div`
-  margin-top: 20px;
   width: 100%;
 `;
 
 export const AreaInfoBar = styled.div`
   display: flex;
-  margin-top: 10px;
   gap: 10px;
   justify-content: space-between;
   align-items: center;
 `;
 
-export const InfoText = styled.div`
-  margin-top: 10px;
+export const InfoText = styled.span`
+  margin-left: 10px;
   color: ${({ theme }) => theme.colors.GRAY_600};
-  font-size: 15px;
+  font-size: 14px;
+`;
+
+export const AccountRow = styled.div`
+  display: flex;
+  gap: 10px;
+  flex-direction: column;
 `;

--- a/src/features/user/ui/EditProfile.styles.ts
+++ b/src/features/user/ui/EditProfile.styles.ts
@@ -1,10 +1,20 @@
 import styled from 'styled-components';
 
+export const Container = styled.div`
+  width: 100%;
+  margin-top: 50px;
+  padding: 10px;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
+    margin: 0;
+  }
+`;
 export const NicknameSection = styled.div`
   margin-top: 10px;
   display: flex;
   gap: 10px;
   align-items: start;
+  max-width: 390px;
 `;
 
 export const ButtonWrapper = styled.div`

--- a/src/features/user/ui/EditProfile.styles.ts
+++ b/src/features/user/ui/EditProfile.styles.ts
@@ -10,3 +10,22 @@ export const NicknameSection = styled.div`
 export const ButtonWrapper = styled.div`
   width: 100px;
 `;
+
+export const EditAreaContainer = styled.div`
+  margin-top: 20px;
+  width: 100%;
+`;
+
+export const AreaInfoBar = styled.div`
+  display: flex;
+  margin-top: 10px;
+  gap: 10px;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const InfoText = styled.div`
+  margin-top: 10px;
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  font-size: 15px;
+`;

--- a/src/features/user/ui/EditProfile.styles.ts
+++ b/src/features/user/ui/EditProfile.styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const NicknameSection = styled.div`
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+  align-items: start;
+`;
+
+export const ButtonWrapper = styled.div`
+  width: 100px;
+`;

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,0 +1,70 @@
+import DefaultProfile from '@/shared/assets/default-profile.svg';
+import { nicknameRule } from '@/shared/constants';
+import { Button, InputGroup } from '@/shared/ui';
+import { useForm, useWatch } from 'react-hook-form';
+import styled from 'styled-components';
+
+interface EditProfileValues {
+  nickname: string;
+  password: string;
+  newPassword: string;
+  passwordConfirm: string;
+}
+const EditProfile = () => {
+  // #todo: 기본값 처리
+  const defaultNickname = '지지';
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useForm<EditProfileValues>({
+    defaultValues: {
+      nickname: defaultNickname,
+    },
+    mode: 'onChange',
+  });
+
+  const nickname = useWatch({ name: 'nickname', control });
+  const nicknameDisabled =
+    !nickname || errors.nickname || nickname === defaultNickname;
+  function handleEditNickname() {}
+  return (
+    <div style={{ width: '100%', marginTop: 50 }}>
+      <DefaultProfile width={100} />
+      <NicknameSection>
+        <InputGroup
+          inputs={[
+            {
+              name: 'nickname',
+              placeholder: '별명',
+              type: 'text',
+              rules: nicknameRule,
+            },
+          ]}
+          register={register}
+          errors={{ nickname: errors.nickname }}
+        />
+        <ButtonWrapper>
+          <Button
+            text='수정'
+            variant={nicknameDisabled ? 'disabled' : 'primary'}
+            onClick={handleEditNickname}
+          />
+        </ButtonWrapper>
+      </NicknameSection>
+    </div>
+  );
+};
+
+export default EditProfile;
+
+const NicknameSection = styled.div`
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+  align-items: start;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100px;
+`;

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,70 +1,14 @@
 import DefaultProfile from '@/shared/assets/default-profile.svg';
-import { nicknameRule } from '@/shared/constants';
-import { Button, InputGroup } from '@/shared/ui';
-import { useForm, useWatch } from 'react-hook-form';
-import styled from 'styled-components';
+import EditNickname from './EditNickname';
 
-interface EditProfileValues {
-  nickname: string;
-  password: string;
-  newPassword: string;
-  passwordConfirm: string;
-}
 const EditProfile = () => {
   // #todo: 기본값 처리
-  const defaultNickname = '지지';
-  const {
-    register,
-    control,
-    formState: { errors },
-  } = useForm<EditProfileValues>({
-    defaultValues: {
-      nickname: defaultNickname,
-    },
-    mode: 'onChange',
-  });
-
-  const nickname = useWatch({ name: 'nickname', control });
-  const nicknameDisabled =
-    !nickname || errors.nickname || nickname === defaultNickname;
-  function handleEditNickname() {}
   return (
     <div style={{ width: '100%', marginTop: 50 }}>
       <DefaultProfile width={100} />
-      <NicknameSection>
-        <InputGroup
-          inputs={[
-            {
-              name: 'nickname',
-              placeholder: '별명',
-              type: 'text',
-              rules: nicknameRule,
-            },
-          ]}
-          register={register}
-          errors={{ nickname: errors.nickname }}
-        />
-        <ButtonWrapper>
-          <Button
-            text='수정'
-            variant={nicknameDisabled ? 'disabled' : 'primary'}
-            onClick={handleEditNickname}
-          />
-        </ButtonWrapper>
-      </NicknameSection>
+      <EditNickname />
     </div>
   );
 };
 
 export default EditProfile;
-
-const NicknameSection = styled.div`
-  margin-top: 10px;
-  display: flex;
-  gap: 10px;
-  align-items: start;
-`;
-
-const ButtonWrapper = styled.div`
-  width: 100px;
-`;

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,12 +1,14 @@
 import DefaultProfile from '@/shared/assets/default-profile.svg';
 import EditNickname from './EditNickname';
+import EditArea from './EditArea';
 
 const EditProfile = () => {
   // #todo: 기본값 처리
   return (
-    <div style={{ width: '100%', marginTop: 50 }}>
+    <div style={{ width: '100%', marginTop: 50, padding: 10 }}>
       <DefaultProfile width={100} />
       <EditNickname />
+      <EditArea />
     </div>
   );
 };

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,6 +1,7 @@
 import DefaultProfile from '@/shared/assets/default-profile.svg';
 import EditNickname from './EditNickname';
 import EditArea from './EditArea';
+import EditPassword from './EditPassword';
 
 const EditProfile = () => {
   // #todo: 기본값 처리
@@ -9,6 +10,7 @@ const EditProfile = () => {
       <DefaultProfile width={100} />
       <EditNickname />
       <EditArea />
+      <EditPassword />
     </div>
   );
 };

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -6,12 +6,21 @@ import EditArea from './EditArea';
 
 const EditProfile = () => {
   // #todo: 기본값 처리
+  function handleLogout() {}
+  function handleDeleteAccount() {}
   return (
     <S.Container>
-      <DefaultProfile width={100} />
+      <DefaultProfile width={80} />
       <EditNickname />
       <EditArea />
       <EditPassword />
+      <S.AccountRow>
+        <div style={{ fontWeight: 600 }}>계정</div>
+        <S.AccountButton onClick={handleLogout}>로그아웃</S.AccountButton>
+        <S.AccountButton onClick={handleDeleteAccount}>
+          회원 탈퇴
+        </S.AccountButton>
+      </S.AccountRow>
     </S.Container>
   );
 };

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,17 +1,18 @@
 import DefaultProfile from '@/shared/assets/default-profile.svg';
 import EditNickname from './EditNickname';
-import EditArea from './EditArea';
 import EditPassword from './EditPassword';
+import * as S from './EditProfile.styles';
+import EditArea from './EditArea';
 
 const EditProfile = () => {
   // #todo: 기본값 처리
   return (
-    <div style={{ width: '100%', marginTop: 50, padding: 10 }}>
+    <S.Container>
       <DefaultProfile width={100} />
       <EditNickname />
       <EditArea />
       <EditPassword />
-    </div>
+    </S.Container>
   );
 };
 

--- a/src/features/user/ui/My.tsx
+++ b/src/features/user/ui/My.tsx
@@ -1,0 +1,5 @@
+const My = () => {
+  return <div></div>;
+};
+
+export default My;

--- a/src/features/user/ui/My.tsx
+++ b/src/features/user/ui/My.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 import MyTab from './MyTab';
+import EditProfile from './EditProfile';
+import MyFavorite from './MyFavorite';
+import MyBook from './MyBook';
+import styled from 'styled-components';
 
 const My = () => {
   const [selected, setSelected] = useState(0);
@@ -7,10 +11,23 @@ const My = () => {
     setSelected(value);
   }
   return (
-    <div>
+    <Container>
       <MyTab selected={selected} onClick={handleClickTab} />
-    </div>
+      {selected === 0 ? (
+        <EditProfile />
+      ) : selected === 1 ? (
+        <MyFavorite />
+      ) : (
+        <MyBook />
+      )}
+    </Container>
   );
 };
 
 export default My;
+
+const Container = styled.div`
+  @media (min-width: ${({ theme }) => theme.breakpoints.tablet}) {
+    display: flex;
+  }
+`;

--- a/src/features/user/ui/My.tsx
+++ b/src/features/user/ui/My.tsx
@@ -1,5 +1,16 @@
+import { useState } from 'react';
+import MyTab from './MyTab';
+
 const My = () => {
-  return <div></div>;
+  const [selected, setSelected] = useState(0);
+  function handleClickTab(value: number) {
+    setSelected(value);
+  }
+  return (
+    <div>
+      <MyTab selected={selected} onClick={handleClickTab} />
+    </div>
+  );
 };
 
 export default My;

--- a/src/features/user/ui/MyBook.tsx
+++ b/src/features/user/ui/MyBook.tsx
@@ -1,0 +1,5 @@
+const MyBook = () => {
+  return <div></div>;
+};
+
+export default MyBook;

--- a/src/features/user/ui/MyFavorite.tsx
+++ b/src/features/user/ui/MyFavorite.tsx
@@ -1,0 +1,5 @@
+const MyFavorite = () => {
+  return <div></div>;
+};
+
+export default MyFavorite;

--- a/src/features/user/ui/MyTab.tsx
+++ b/src/features/user/ui/MyTab.tsx
@@ -66,7 +66,7 @@ const ListItem = styled.li<ListItemProps>`
   }
 
   @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
-    font-size: 18px;
+    font-size: 16px;
     text-align: center;
     padding: 10px;
     border-bottom: ${({ $isSelect, theme }) =>

--- a/src/features/user/ui/MyTab.tsx
+++ b/src/features/user/ui/MyTab.tsx
@@ -25,9 +25,9 @@ const MyTab = ({ selected, onClick }: MyTabProps) => {
 export default MyTab;
 
 const Container = styled.div`
-  width: 250px;
+  width: 350px;
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
     width: 100%;
   }
 `;
@@ -38,7 +38,7 @@ const ListWrapper = styled.ul`
   padding: 20px;
   list-style: inside;
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
     height: auto;
@@ -65,7 +65,7 @@ const ListItem = styled.li<ListItemProps>`
       $isSelect ? theme.colors.PRIMARY : theme.colors.BLACK};
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
     font-size: 18px;
     text-align: center;
     padding: 10px;

--- a/src/features/user/ui/MyTab.tsx
+++ b/src/features/user/ui/MyTab.tsx
@@ -1,0 +1,75 @@
+import styled from 'styled-components';
+
+interface MyTabProps {
+  selected: number;
+  onClick: (v: number) => void;
+}
+const MyTab = ({ selected, onClick }: MyTabProps) => {
+  const tabs = ['내 프로필', '내가 찜한 책', '내 판매글'];
+  return (
+    <Container>
+      <ListWrapper>
+        {tabs.map((label, i) => (
+          <ListItem
+            $isSelect={selected === i}
+            key={i}
+            className={i === selected ? 'active' : ''}
+            onClick={() => onClick(i)}>
+            {label}
+          </ListItem>
+        ))}
+      </ListWrapper>
+    </Container>
+  );
+};
+export default MyTab;
+
+const Container = styled.div`
+  width: 250px;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    width: 100%;
+  }
+`;
+
+const ListWrapper = styled.ul`
+  width: 100%;
+  height: 100vh;
+  padding: 20px;
+  list-style: inside;
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    height: auto;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-bottom: 5px solid ${({ theme }) => theme.colors.GRAY_300};
+  }
+`;
+
+interface ListItemProps {
+  $isSelect: boolean;
+}
+const ListItem = styled.li<ListItemProps>`
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: 600;
+  padding: 20px 0;
+  color: ${({ $isSelect, theme }) =>
+    $isSelect ? theme.colors.BLACK : theme.colors.GRAY_500};
+
+  &::marker {
+    color: ${({ $isSelect, theme }) =>
+      $isSelect ? theme.colors.PRIMARY : theme.colors.BLACK};
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    font-size: 18px;
+    text-align: center;
+    padding: 10px;
+    border-bottom: ${({ $isSelect, theme }) =>
+      $isSelect ? `4px solid ${theme.colors.PRIMARY}` : 'none'};
+  }
+`;

--- a/src/features/user/ui/index.ts
+++ b/src/features/user/ui/index.ts
@@ -1,0 +1,3 @@
+import My from './My';
+
+export { My };

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -9,7 +9,7 @@ const BUTTON_STYLE = {
   lg: { width: '370px', height: '50px', fontSize: '18px' },
 } as const;
 
-type Variant = 'primary' | 'cancel' | 'disabled';
+type Variant = 'primary' | 'secondary' | 'cancel' | 'disabled';
 
 const Button = ({
   text,
@@ -62,11 +62,16 @@ const StyledButton = styled.button<ButtonProps>`
           color: ${theme.colors.GRAY_500};
           cursor: not-allowed;
         `;
+      case 'secondary':
+        return `
+          background-color: ${theme.colors.SECONDARY};
+          color: ${colors.light.WHITE};
+        `;
       case 'primary':
       default:
         return `
           background-color: ${theme.colors.PRIMARY};
-          color: ${theme.colors.WHITE};
+          color: ${colors.light.WHITE};
         `;
     }
   }}

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -15,7 +15,7 @@ import {
 } from '../assets/icons';
 
 // #todo: isLogin zustand로 관리 예정
-const isLogin = false;
+const isLogin = true;
 
 const Header = () => {
   const { mode, toggleMode } = useThemeStore();
@@ -49,7 +49,19 @@ const Header = () => {
         </div>
         {isLogin ? (
           <S.IconGroup>
-            <UserIcon stroke={theme.colors.BLACK} strokeWidth={2} fill='none' />
+            <Link
+              href='/my'
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
+              <UserIcon
+                stroke={theme.colors.BLACK}
+                strokeWidth={2}
+                fill='none'
+              />
+            </Link>
             <NotiIcon stroke={theme.colors.BLACK} strokeWidth={2} fill='none' />
           </S.IconGroup>
         ) : (

--- a/src/shared/ui/InputGroup.styles.ts
+++ b/src/shared/ui/InputGroup.styles.ts
@@ -32,7 +32,7 @@ export const Input = styled.input`
   flex: 1;
   border: none;
   outline: none;
-  font-size: 12px;
+  font-size: 14px;
   color: ${({ theme }) => theme.colors.BLACK};
   background-color: transparent;
   caret-color: ${({ theme }) => theme.colors.BLACK};
@@ -51,5 +51,5 @@ export const Input = styled.input`
 
 export const ErrorMessage = styled.p`
   color: ${colors.light.ERROR};
-  font-size: 10px;
+  font-size: 12px;
 `;

--- a/src/shared/ui/InputGroup.styles.ts
+++ b/src/shared/ui/InputGroup.styles.ts
@@ -8,14 +8,12 @@ interface InputWrapperProps {
 
 export const Container = styled.div`
   width: 100%;
-  max-width: 300px;
 `;
 
 export const InputContainer = styled.div`
   border: 1px solid ${colors.light.GRAY_500};
   border-radius: 12px;
   width: 100%;
-  max-width: 300px;
 `;
 
 export const InputWrapper = styled.div<InputWrapperProps>`

--- a/src/shared/ui/SelectAreaSection.tsx
+++ b/src/shared/ui/SelectAreaSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import styled from 'styled-components';
-import { Dropdown } from '@/shared/ui';
+import { Button, Dropdown } from '@/shared/ui';
 import { colors } from '../constants';
 import sido_areas from '@/shared/constants/sido_areas.json';
 import sigg_areas from '@/shared/constants/sigg_areas.json';
@@ -21,6 +21,8 @@ export interface AreaState {
 
 export interface SelectAreaSectionProps {
   showVerifyButton?: boolean;
+  showEditButton?: boolean;
+  onClickEdit?: () => void;
 }
 
 export interface SelectAreaSectionRef {
@@ -33,99 +35,117 @@ export interface SelectAreaSectionRef {
 export const SelectAreaSection = forwardRef<
   SelectAreaSectionRef,
   SelectAreaSectionProps
->(({ showVerifyButton = true }: SelectAreaSectionProps, ref) => {
-  const [sidoId, setSidoId] = useState<number | undefined>(undefined);
-  const [siggId, setSiggId] = useState<number | undefined>(undefined);
-  const [emdId, setEmdId] = useState<number | undefined>(undefined);
+>(
+  (
+    {
+      showVerifyButton = true,
+      showEditButton = false,
+      onClickEdit,
+    }: SelectAreaSectionProps,
+    ref,
+  ) => {
+    const [sidoId, setSidoId] = useState<number | undefined>(undefined);
+    const [siggId, setSiggId] = useState<number | undefined>(undefined);
+    const [emdId, setEmdId] = useState<number | undefined>(undefined);
 
-  useImperativeHandle(ref, () => ({
-    getSelection: () => ({ sidoId, siggId, emdId }),
-  }));
-  const [openDropdown, setOpenDropdown] = useState<string | null>('');
-  const isDisabled = !sidoId || !siggId || !emdId;
+    useImperativeHandle(ref, () => ({
+      getSelection: () => ({ sidoId, siggId, emdId }),
+    }));
+    const [openDropdown, setOpenDropdown] = useState<string | null>('');
+    const isDisabled = !sidoId || !siggId || !emdId;
 
-  function handleToggleDropdown(value: number) {
-    setOpenDropdown((prev) =>
-      prev === AreaType[value] ? null : AreaType[value],
+    function handleToggleDropdown(value: number) {
+      setOpenDropdown((prev) =>
+        prev === AreaType[value] ? null : AreaType[value],
+      );
+    }
+
+    // 상위 지역이 변경되면 하위 지역은 리셋되어야 함
+    function handleSelectSido(value: number) {
+      if (sidoId && value !== sidoId) {
+        setSiggId(undefined);
+        setEmdId(undefined);
+      }
+      setSidoId(value);
+    }
+
+    function handleSelectSigg(value: number) {
+      if (siggId && value !== siggId) {
+        setEmdId(undefined);
+      }
+      setSiggId(value);
+    }
+
+    function handleSelectEmd(value: number) {
+      setEmdId(value);
+    }
+
+    function handleAreaVerify() {
+      console.log(emdId);
+    }
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 10,
+        }}>
+        <Dropdown
+          category={1}
+          isOpen={openDropdown === 'sido'}
+          onToggle={handleToggleDropdown}
+          options={sido_areas}
+          placeholder='시/도'
+          onSelect={handleSelectSido}
+          onClose={() => setOpenDropdown(null)}
+          selectedId={sidoId}
+          isResponsive={!showVerifyButton}
+        />
+        <Dropdown
+          category={2}
+          isOpen={openDropdown === 'sigg'}
+          onToggle={handleToggleDropdown}
+          options={sigg_areas
+            .filter((value) => value.sido_area_id === sidoId)
+            .sort((a, b) => a.name.localeCompare(b.name))}
+          placeholder='시/군/구'
+          onSelect={handleSelectSigg}
+          onClose={() => setOpenDropdown(null)}
+          selectedId={siggId}
+          isResponsive={!showVerifyButton}
+        />
+        <Dropdown
+          category={3}
+          isOpen={openDropdown === 'emd'}
+          onToggle={handleToggleDropdown}
+          options={emd_areas
+            .filter((value) => value.sigg_area_id == siggId)
+            .sort((a, b) => a.name.localeCompare(b.name))}
+          placeholder='읍/면/동'
+          onSelect={handleSelectEmd}
+          onClose={() => setOpenDropdown(null)}
+          selectedId={emdId}
+          isResponsive={!showVerifyButton}
+        />
+        {showVerifyButton && (
+          <StyledButton disabled={isDisabled} onClick={handleAreaVerify}>
+            위치 인증
+          </StyledButton>
+        )}
+        {showEditButton && onClickEdit && (
+          <div style={{ width: 100 }}>
+            <Button
+              text='수정'
+              variant={emdId ? 'disabled' : 'primary'}
+              onClick={onClickEdit}
+            />
+          </div>
+        )}
+      </div>
     );
-  }
-
-  // 상위 지역이 변경되면 하위 지역은 리셋되어야 함
-  function handleSelectSido(value: number) {
-    if (sidoId && value !== sidoId) {
-      setSiggId(undefined);
-      setEmdId(undefined);
-    }
-    setSidoId(value);
-  }
-
-  function handleSelectSigg(value: number) {
-    if (siggId && value !== siggId) {
-      setEmdId(undefined);
-    }
-    setSiggId(value);
-  }
-
-  function handleSelectEmd(value: number) {
-    setEmdId(value);
-  }
-
-  function handleAreaVerify() {
-    console.log(emdId);
-  }
-
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 10,
-      }}>
-      <Dropdown
-        category={1}
-        isOpen={openDropdown === 'sido'}
-        onToggle={handleToggleDropdown}
-        options={sido_areas}
-        placeholder='시/도'
-        onSelect={handleSelectSido}
-        onClose={() => setOpenDropdown(null)}
-        selectedId={sidoId}
-        isResponsive={!showVerifyButton}
-      />
-      <Dropdown
-        category={2}
-        isOpen={openDropdown === 'sigg'}
-        onToggle={handleToggleDropdown}
-        options={sigg_areas
-          .filter((value) => value.sido_area_id === sidoId)
-          .sort((a, b) => a.name.localeCompare(b.name))}
-        placeholder='시/군/구'
-        onSelect={handleSelectSigg}
-        onClose={() => setOpenDropdown(null)}
-        selectedId={siggId}
-        isResponsive={!showVerifyButton}
-      />
-      <Dropdown
-        category={3}
-        isOpen={openDropdown === 'emd'}
-        onToggle={handleToggleDropdown}
-        options={emd_areas
-          .filter((value) => value.sigg_area_id == siggId)
-          .sort((a, b) => a.name.localeCompare(b.name))}
-        placeholder='읍/면/동'
-        onSelect={handleSelectEmd}
-        onClose={() => setOpenDropdown(null)}
-        selectedId={emdId}
-        isResponsive={!showVerifyButton}
-      />
-      {showVerifyButton && (
-        <StyledButton disabled={isDisabled} onClick={handleAreaVerify}>
-          위치 인증
-        </StyledButton>
-      )}
-    </div>
-  );
-});
+  },
+);
 
 SelectAreaSection.displayName = 'SelectAreaSection';
 

--- a/src/shared/ui/SelectAreaSection.tsx
+++ b/src/shared/ui/SelectAreaSection.tsx
@@ -137,7 +137,7 @@ export const SelectAreaSection = forwardRef<
           <div style={{ width: 100 }}>
             <Button
               text='수정'
-              variant={emdId ? 'disabled' : 'primary'}
+              variant={emdId ? 'primary' : 'disabled'}
               onClick={onClickEdit}
             />
           </div>

--- a/src/shared/ui/SelectAreaSection.tsx
+++ b/src/shared/ui/SelectAreaSection.tsx
@@ -150,9 +150,9 @@ export const SelectAreaSection = forwardRef<
 SelectAreaSection.displayName = 'SelectAreaSection';
 
 const StyledButton = styled.button<{ disabled: boolean }>`
-  ${({ disabled = true }) =>
-    `background-color: ${disabled ? colors.light.GRAY_300 : colors.light.PRIMARY};
-    color: ${disabled ? colors.light.GRAY_500 : colors.light.WHITE};
+  ${({ disabled = true, theme }) =>
+    `background-color: ${disabled ? theme.colors.GRAY_300 : colors.light.PRIMARY};
+    color: ${disabled ? theme.colors.GRAY_500 : colors.light.WHITE};
     cursor: ${disabled ? 'default' : 'pointer'};
   `}
   width: 145px;


### PR DESCRIPTION
### #️⃣연관된 이슈
> #20 

### 📜 작업 내용
- [x] 마이페이지 링크 연결
- [x] 마이페이지 - 탭 구현(데스크탑, 모바일 스타일 분기)
- [x] 공통 버튼 컴포넌트 variant 옵션 추가 ('secondary')
- [x] 마이페이지 - 내 프로필 UI 구현

### 🖼️ 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/acd3f8c1-8e61-4180-9cc3-92eb4399a5d8" width=500 />
<img src="https://github.com/user-attachments/assets/a83c65e8-0edf-401c-ac52-42d06e3f034b" width=200 />


### ⚠️ 종료할 이슈
this closes #20 
