### PR TITLE
Feat#47: 로그인/로그아웃 api 연동

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,9 +4,10 @@ import localFont from 'next/font/local';
 import { ToastContainer } from 'react-toastify';
 import StyledComponentsRegistry from '@/shared/lib/StyledComponentsRegistry';
 import { ReactQueryClientProvider, ThemeRegistry } from '@/shared/providers';
-import { FloatingButton, Header } from '@/shared/ui';
+import { FloatingButton } from '@/shared/ui';
 import { ChatWidget } from '@/features/chat/ui';
 import { GlobalErrorBoundary } from '@/shared/lib';
+import { Header } from '@/features/header/ui';
 
 const pretendard = localFont({
   src: '../shared/assets/fonts/PretendardVariable.woff2',

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/shared/config/axios';
-import { patchAreaProps, postLoginProps, postSignUpProps } from './type';
+import { patchAreaProps, postLoginProps, postSignUpProps } from '.';
 
 export const postEmailVerify = async ({ email }: { email: string }) => {
   const { data } = await axiosInstance.post('/auth/email', { email });

--- a/src/entities/auth/api.ts
+++ b/src/entities/auth/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/shared/config/axios';
-import { patchAreaProps, postSignUpProps } from './type';
+import { patchAreaProps, postLoginProps, postSignUpProps } from './type';
 
 export const postEmailVerify = async ({ email }: { email: string }) => {
   const { data } = await axiosInstance.post('/auth/email', { email });
@@ -27,5 +27,15 @@ export const patchArea = async (area: patchAreaProps) => {
 
 export const postSignUp = async (user: postSignUpProps) => {
   const { data } = await axiosInstance.post('/members', user);
+  return data;
+};
+
+export const postLogin = async (user: postLoginProps) => {
+  const { data } = await axiosInstance.post('/auth/login', user);
+  return data;
+};
+
+export const postLogout = async () => {
+  const { data } = await axiosInstance.post('/auth/logout');
   return data;
 };

--- a/src/entities/auth/queries.ts
+++ b/src/entities/auth/queries.ts
@@ -15,10 +15,13 @@ import {
 import { queryClient } from '@/shared/lib';
 
 export const useSignupMutation = () => {
+  const login = useLoginMutation();
+
   return useMutation<void, Error, postSignUpProps>({
     mutationFn: (data) => postSignUp(data),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       toast.success('회원가입 완료!');
+      login.mutate({ email: variables.email, password: variables.password });
     },
   });
 };
@@ -54,7 +57,8 @@ export const useLoginMutation = () => {
   const router = useRouter();
   return useMutation<void, Error, postLoginProps>({
     mutationFn: (data) => postLogin(data),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['my'] });
       router.replace('/');
     },
   });

--- a/src/entities/auth/queries.ts
+++ b/src/entities/auth/queries.ts
@@ -8,8 +8,11 @@ import {
   postLogin,
   postLogout,
   postSignUp,
-} from './api';
-import { patchAreaProps, postLoginProps, postSignUpProps } from './type';
+  patchAreaProps,
+  postLoginProps,
+  postSignUpProps,
+} from '.';
+import { queryClient } from '@/shared/lib';
 
 export const useSignupMutation = () => {
   return useMutation<void, Error, postSignUpProps>({
@@ -62,6 +65,7 @@ export const useLogoutMutation = () => {
   return useMutation<void, Error>({
     mutationFn: postLogout,
     onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ['my'] });
       router.replace('/');
     },
   });

--- a/src/entities/auth/queries.ts
+++ b/src/entities/auth/queries.ts
@@ -1,17 +1,21 @@
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/navigation';
 import { useMutation } from '@tanstack/react-query';
-import { patchArea, postCodeVerify, postEmailVerify, postSignUp } from './api';
-import { patchAreaProps, postSignUpProps } from './type';
+import {
+  patchArea,
+  postCodeVerify,
+  postEmailVerify,
+  postLogin,
+  postLogout,
+  postSignUp,
+} from './api';
+import { patchAreaProps, postLoginProps, postSignUpProps } from './type';
 
 export const useSignupMutation = () => {
-  const router = useRouter();
-
   return useMutation<void, Error, postSignUpProps>({
     mutationFn: (data) => postSignUp(data),
     onSuccess: () => {
       toast.success('회원가입 완료!');
-      router.replace('/');
     },
   });
 };
@@ -39,6 +43,26 @@ export const useAreaMutation = () => {
     mutationFn: (data) => patchArea(data),
     onSuccess: () => {
       toast.success('인증 완료! 계속 진행해 주세요');
+    },
+  });
+};
+
+export const useLoginMutation = () => {
+  const router = useRouter();
+  return useMutation<void, Error, postLoginProps>({
+    mutationFn: (data) => postLogin(data),
+    onSuccess: () => {
+      router.replace('/');
+    },
+  });
+};
+
+export const useLogoutMutation = () => {
+  const router = useRouter();
+  return useMutation<void, Error>({
+    mutationFn: postLogout,
+    onSuccess: () => {
+      router.replace('/');
     },
   });
 };

--- a/src/entities/auth/type.ts
+++ b/src/entities/auth/type.ts
@@ -13,3 +13,8 @@ export interface postSignUpProps {
   password: string;
   emdId: number;
 }
+
+export interface postLoginProps {
+  email: string;
+  password: string;
+}

--- a/src/entities/user/api.ts
+++ b/src/entities/user/api.ts
@@ -1,0 +1,6 @@
+import axiosInstance from '@/shared/config/axios';
+
+export const getMyProfile = async () => {
+  const { data } = await axiosInstance.get('/members/me');
+  return data;
+};

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './queries';

--- a/src/entities/user/queries.ts
+++ b/src/entities/user/queries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMyProfile } from './api';
+
+export const useMyQuery = () => {
+  return useQuery({
+    queryKey: ['my'],
+    queryFn: getMyProfile,
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 5,
+    throwOnError: false,
+  });
+};

--- a/src/features/auth/ui/LoginForm.tsx
+++ b/src/features/auth/ui/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useForm, useWatch } from 'react-hook-form';
 import { InputGroup, Button } from '@/shared/ui';
 import { emailRule, passwordBasicRule } from '@/shared/constants';
 import styled from 'styled-components';
+import { useLoginMutation } from '@/entities/auth/queries';
 
 interface LoginFormValues {
   email: string;
@@ -22,8 +23,9 @@ const LoginForm = () => {
   const password = useWatch({ name: 'password', control });
   const disabled = !email || !password || Object.keys(errors).length > 0;
 
+  const { mutate: login } = useLoginMutation();
   function handleClickLogin() {
-    console.log('login');
+    login({ email, password });
   }
   return (
     <Container>

--- a/src/features/header/ui/Header.styles.ts
+++ b/src/features/header/ui/Header.styles.ts
@@ -1,6 +1,6 @@
 'use client';
 import styled from 'styled-components';
-import { colors } from '../constants';
+import { colors } from '../../../shared/constants';
 
 export const Container = styled.header`
   height: 60px;

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -4,21 +4,22 @@ import Link from 'next/link';
 import { useTheme } from 'styled-components';
 import { useRouter, usePathname } from 'next/navigation';
 import Logo from '@/shared/assets/logo.svg';
-import { useThemeStore } from '../model';
-import { colors } from '../constants';
+import { useThemeStore } from '../../../shared/model';
+import { colors } from '../../../shared/constants';
+import { useMyQuery } from '@/entities/user';
 import * as S from './Header.styles';
 import {
   DarkModeIcon,
   LightModeIcon,
   NotiIcon,
   UserIcon,
-} from '../assets/icons';
-
-// #todo: isLogin zustand로 관리 예정
-const isLogin = true;
+} from '../../../shared/assets/icons';
 
 const Header = () => {
-  const { mode, toggleMode } = useThemeStore();
+  const mode = useThemeStore((state) => state.mode);
+  const toggleMode = useThemeStore((state) => state.toggleMode);
+  const { data, isLoading, isError } = useMyQuery();
+  const isLogin = !isError && !!data?.memberId;
   const theme = useTheme();
   const router = useRouter();
   const pathname = usePathname();
@@ -47,7 +48,7 @@ const Header = () => {
             <LightModeIcon fill={colors.dark.PRIMARY} />
           )}
         </div>
-        {isLogin ? (
+        {!isLoading && isLogin ? (
           <S.IconGroup>
             <Link
               href='/my'
@@ -64,11 +65,11 @@ const Header = () => {
             </Link>
             <NotiIcon stroke={theme.colors.BLACK} strokeWidth={2} fill='none' />
           </S.IconGroup>
-        ) : (
+        ) : !isLoading && !isLogin ? (
           <S.LoginButton onClick={() => router.push('/login')}>
             로그인
           </S.LoginButton>
-        )}
+        ) : null}
       </S.RightSection>
     </S.Container>
   );

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -3,10 +3,10 @@
 import Link from 'next/link';
 import { useTheme } from 'styled-components';
 import { useRouter, usePathname } from 'next/navigation';
-import Logo from '@/shared/assets/logo.svg';
 import { useThemeStore } from '../../../shared/model';
 import { colors } from '../../../shared/constants';
 import { useMyQuery } from '@/entities/user';
+import Logo from '@/shared/assets/logo.svg';
 import * as S from './Header.styles';
 import {
   DarkModeIcon,

--- a/src/features/header/ui/index.ts
+++ b/src/features/header/ui/index.ts
@@ -1,0 +1,3 @@
+import Header from './Header';
+
+export { Header };

--- a/src/features/user/ui/EditProfile.tsx
+++ b/src/features/user/ui/EditProfile.tsx
@@ -1,4 +1,5 @@
 import DefaultProfile from '@/shared/assets/default-profile.svg';
+import { useLogoutMutation } from '@/entities/auth/queries';
 import EditNickname from './EditNickname';
 import EditPassword from './EditPassword';
 import * as S from './EditProfile.styles';
@@ -6,7 +7,11 @@ import EditArea from './EditArea';
 
 const EditProfile = () => {
   // #todo: 기본값 처리
-  function handleLogout() {}
+
+  const { mutate: logout } = useLogoutMutation();
+  function handleLogout() {
+    logout();
+  }
   function handleDeleteAccount() {}
   return (
     <S.Container>

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,7 +1,6 @@
 import Button from './Button';
 import Dropdown from './Dropdown';
 import FloatingButton from './FloatingButton';
-import Header from './Header';
 import InputGroup from './InputGroup';
 import { SelectAreaSection } from './SelectAreaSection';
 import CheckBox from './CheckBox';
@@ -14,7 +13,6 @@ export {
   CheckCircle,
   Dropdown,
   FloatingButton,
-  Header,
   InputGroup,
   ModalLayout,
   FallbackGlobal,


### PR DESCRIPTION
### #️⃣연관된 이슈
> #47 

### 📜 작업 내용
- [x] 로그인, 로그아웃 api 연동
- [x] 회원가입 후 자동 로그인
- [x] 내 정보 조회로 로그인 여부 파악 -> 헤더에 반영


### ⚠️ 종료할 이슈
this closes #47
