### PR TITLE
feat#61: 임시 비밀번호 발급 API 연동

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
                 {children}
                 <FloatingButton />
                 <ChatWidget />
-                <ToastContainer />
+                <ToastContainer autoClose={1000} hideProgressBar />
               </GlobalErrorBoundary>
             </ThemeRegistry>
           </ReactQueryClientProvider>

--- a/src/app/password/request/page.tsx
+++ b/src/app/password/request/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { PasswordRequestLayout } from '@/features/auth/ui';
+import { PasswordRequestLayout } from '@/features/user/ui';
 import styled from 'styled-components';
 const PasswordRequestPage = () => {
   return (

--- a/src/entities/user/api.ts
+++ b/src/entities/user/api.ts
@@ -18,3 +18,10 @@ export const patchPassword = async (password: patchPasswordProps) => {
   const { data } = await axiosInstance.patch('/members/me/password', password);
   return data;
 };
+
+export const patchTempPassword = async (email: string) => {
+  const { data } = await axiosInstance.patch('/members/temp/password', {
+    email,
+  });
+  return data;
+};

--- a/src/entities/user/queries.ts
+++ b/src/entities/user/queries.ts
@@ -5,6 +5,7 @@ import {
   patchNickname,
   patchPassword,
   patchPasswordProps,
+  patchTempPassword,
 } from './api';
 import { queryClient } from '@/shared/lib';
 
@@ -23,7 +24,7 @@ export const useMyInfoMutation = () => {
   return useMutation<void, Error, string>({
     mutationFn: (data) => patchNickname(data),
     onSuccess: () => {
-      toast.success('닉네임 변경 완료!');
+      toast.success('닉네임 변경 완료');
       queryClient.invalidateQueries({ queryKey: ['my'] });
     },
   });
@@ -34,6 +35,15 @@ export const usePasswordMutation = () => {
     mutationFn: (data) => patchPassword(data),
     onSuccess: () => {
       toast.success('비밀번호 변경 완료');
+    },
+  });
+};
+
+export const useTempPasswordMutation = () => {
+  return useMutation<void, Error, string>({
+    mutationFn: (data) => patchTempPassword(data),
+    onSuccess: () => {
+      toast.success('임시 비밀번호를 발급했습니다. 메일함을 확인해 주세요');
     },
   });
 };

--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,4 +1,3 @@
 import LoginLayout from './LoginLayout';
 import SignUpLayout from './signup/SignUpLayout';
-import PasswordRequestLayout from './PasswordRequestLayout';
-export { LoginLayout, SignUpLayout, PasswordRequestLayout };
+export { LoginLayout, SignUpLayout };

--- a/src/features/user/ui/PasswordRequestLayout.tsx
+++ b/src/features/user/ui/PasswordRequestLayout.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import Link from 'next/link';
+import { useState } from 'react';
 import styled from 'styled-components';
-import { colors, emailRule } from '@/shared/constants';
-import { InputGroup } from '@/shared/ui';
 import { useForm, useWatch } from 'react-hook-form';
 import { StyledButton } from '../../auth/ui/signup/SignUpForm.styles';
-import { useState } from 'react';
 import { ErrorIcon, SuccessIcon } from '@/shared/assets/icons';
+import { useTempPasswordMutation } from '@/entities/user';
+import { colors, emailRule } from '@/shared/constants';
 import Logo from '@/shared/assets/logo-text.svg';
+import { InputGroup } from '@/shared/ui';
 
 const PasswordRequestLayout = () => {
   const {
@@ -20,7 +21,8 @@ const PasswordRequestLayout = () => {
   });
 
   const email = useWatch({ name: 'email', control });
-  const [isSuccess, setIsSuccess] = useState<boolean | null>(null);
+  const { mutate: tempPassword, isSuccess } = useTempPasswordMutation();
+  const [isSubmitted, setIsSubmitted] = useState(false);
 
   const isDisabled = !email || Object.keys(errors).length > 0;
 
@@ -32,10 +34,8 @@ const PasswordRequestLayout = () => {
         : '해당 이메일로 가입된 계정을 찾을 수 없습니다\n이메일을 다시 확인해주세요';
 
   function handleClickConfirm() {
-    setIsSuccess((prev) => {
-      if (prev === null) return true;
-      else return !prev;
-    });
+    setIsSubmitted(true);
+    tempPassword(email);
   }
   return (
     <Container>
@@ -61,7 +61,7 @@ const PasswordRequestLayout = () => {
         register={register}
         errors={errors}
       />
-      {isSuccess !== null && (
+      {isSubmitted && (
         <div
           style={{
             display: 'flex',

--- a/src/features/user/ui/PasswordRequestLayout.tsx
+++ b/src/features/user/ui/PasswordRequestLayout.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { colors, emailRule } from '@/shared/constants';
 import { InputGroup } from '@/shared/ui';
 import { useForm, useWatch } from 'react-hook-form';
-import { StyledButton } from './signup/SignUpForm.styles';
+import { StyledButton } from '../../auth/ui/signup/SignUpForm.styles';
 import { useState } from 'react';
 import { ErrorIcon, SuccessIcon } from '@/shared/assets/icons';
 import Logo from '@/shared/assets/logo-text.svg';

--- a/src/features/user/ui/index.ts
+++ b/src/features/user/ui/index.ts
@@ -1,3 +1,4 @@
 import My from './My';
+import PasswordRequestLayout from './PasswordRequestLayout';
 
-export { My };
+export { My, PasswordRequestLayout };


### PR DESCRIPTION
### #️⃣연관된 이슈
> #61 

### 📜 작업 내용
- [x] 임시 비밀번호 발급 API 연동
- [x] toast 노출 시간 1초로 변경, 진행 바 숨김

### ⚠️ 종료할 이슈
this closes #61 
