### PR TITLE
feat#63: 알라딘 Open API를 활용한 책 검색 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-toastify": "^11.0.5",
         "styled-components": "^6.1.18",
         "swiper": "^11.2.8",
+        "xml2js": "^0.6.2",
         "zustand": "^5.0.4"
       },
       "devDependencies": {
@@ -27,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.32.0",
         "@typescript-eslint/parser": "^8.32.0",
         "eslint": "^8.57.1",
@@ -3002,6 +3004,16 @@
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.33.1",
@@ -7890,6 +7902,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -9169,6 +9187,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-toastify": "^11.0.5",
     "styled-components": "^6.1.18",
     "swiper": "^11.2.8",
+    "xml2js": "^0.6.2",
     "zustand": "^5.0.4"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.32.0",
     "@typescript-eslint/parser": "^8.32.0",
     "eslint": "^8.57.1",

--- a/src/app/api/aladin/route.ts
+++ b/src/app/api/aladin/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from 'next/server';
+import { parseStringPromise } from 'xml2js';
+
+export async function GET(req: NextRequest) {
+  const query = req.nextUrl.searchParams.get('query');
+  const apiKey = process.env.NEXT_PUBLIC_ALADIN_TTB_KEY;
+
+  try {
+    const response = await fetch(
+      `https://www.aladin.co.kr/ttb/api/ItemSearch.aspx?ttbkey=${apiKey}&Query=${query}&QueryType=Title&MaxResults=100&start=1&SearchTarget=Book&output=xml`,
+    );
+    const xml = await response.text();
+    const data = await parseStringPromise(xml, {
+      explicitArray: false,
+      explicitRoot: false,
+      mergeAttrs: true,
+    });
+
+    if (response.ok) {
+      const item = data.item;
+      const items = Array.isArray(item) ? item : item ? [item] : [];
+      console.log(items);
+      return new Response(JSON.stringify({ ...data, item: items }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } else {
+      return new Response(JSON.stringify({ message: 'Fetch error' }), {
+        status: response.status,
+      });
+    }
+  } catch (error) {
+    console.log(error);
+    return new Response(
+      JSON.stringify({
+        message: 'Internal Server Error',
+        error: (error as Error).message,
+      }),
+      { status: 500 },
+    );
+  }
+}

--- a/src/entities/aladin/api.ts
+++ b/src/entities/aladin/api.ts
@@ -8,6 +8,5 @@ export const searchBook = async (query: string): Promise<AladinResponse> => {
     throw new Error(error.message || 'Failed to fetch search results');
   }
   const data = res.json();
-  console.log(data);
   return data;
 };

--- a/src/entities/aladin/api.ts
+++ b/src/entities/aladin/api.ts
@@ -1,0 +1,13 @@
+import { AladinResponse } from './type';
+
+export const searchBook = async (query: string): Promise<AladinResponse> => {
+  const res = await fetch(`/api/aladin?query=${query}`);
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || 'Failed to fetch search results');
+  }
+  const data = res.json();
+  console.log(data);
+  return data;
+};

--- a/src/entities/aladin/index.ts
+++ b/src/entities/aladin/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/src/entities/aladin/type.ts
+++ b/src/entities/aladin/type.ts
@@ -1,0 +1,13 @@
+export interface AladinItemType {
+  title: string;
+  author: string;
+  pubDate: string;
+  description: string;
+  isbn13: string;
+  itemId: number;
+  priceStandard: number;
+  cover: string;
+}
+export interface AladinResponse {
+  item: AladinItemType[];
+}

--- a/src/features/listing/model/useWriteStore.ts
+++ b/src/features/listing/model/useWriteStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+type BookState = {
+  isbn: string;
+  title: string;
+  author: string;
+  description: string;
+  priceStandard: number;
+  cover: string;
+  pubDate: string;
+};
+type WriteState = {
+  book: BookState | null;
+  setBook: (b: BookState | null) => void;
+};
+
+export const useWriteStore = create<WriteState>((set) => ({
+  book: null,
+  setBook: (b) => set({ book: b }),
+  resetWrite: () => {
+    set({ book: null });
+  },
+}));

--- a/src/features/listing/ui/write/ListingWrite.tsx
+++ b/src/features/listing/ui/write/ListingWrite.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { bookStatusList } from '../main/filter/FilterContent';
+import { useWriteStore } from '../../model/useWriteStore';
 import { BookStatus } from '@/entities/listing/types';
 import { HELP_MESSAGES } from '@/shared/constants';
 import PriceAndCategory from './PriceAndCategory';
+import { Button, CheckCircle } from '@/shared/ui';
 import { bookStatusMap } from '@/shared/lib';
 import SearchSection from './SearchSection';
 import * as S from './ListingWrite.styles';
-import { Button, CheckCircle } from '@/shared/ui';
 import HelpButton from './HelpButton';
 import PhotoList from './PhotoList';
 
@@ -23,9 +24,10 @@ const ListingWrite = ({ id }: ListingWriteProps) => {
   const [images, setImages] = useState<ImageFile[]>([]);
   const [bookStatus, setBookStatus] = useState<BookStatus | null>();
   const [searchTerm, setSearchTerm] = useState<string>('');
-  const [title, setTitle] = useState<string>('파과');
+  const title = useWriteStore((state) => state.book)?.title;
   const [price, setPrice] = useState<string>('');
   const [rawPrice, setRawPrice] = useState<number | null>(null);
+  const book = useWriteStore((state) => state.book);
   const [description, setDescription] = useState<string>('');
 
   function formatNumber(value: string | number) {
@@ -80,7 +82,7 @@ const ListingWrite = ({ id }: ListingWriteProps) => {
       <S.TitleSection>
         <S.HeaderText>제목</S.HeaderText>
         <S.InputWrapper>
-          <S.Input type='text' value={title} readOnly />
+          <S.Input type='text' value={title ?? ''} readOnly />
         </S.InputWrapper>
       </S.TitleSection>
       <S.StatusSection>

--- a/src/features/listing/ui/write/SearchModalContent.tsx
+++ b/src/features/listing/ui/write/SearchModalContent.tsx
@@ -1,28 +1,67 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { SearchIcon } from '@/shared/assets/icons';
-import { data } from '@/mocks/mockBookSearch';
 import * as S from './ListingWrite.styles';
 import { Button } from '@/shared/ui';
+import { searchBook } from '@/entities/aladin';
+import { AladinItemType } from '@/entities/aladin/type';
+import { useWriteStore } from '../../model/useWriteStore';
+import { formatDate } from '@/shared/lib';
 
 interface SearchModalContentProps {
   value: string;
   onClose: () => void;
 }
-// #todo: 판매 정보 zustand로 관리
+
 const SearchModalContent = ({ value, onClose }: SearchModalContentProps) => {
   const [newValue, setNewValue] = useState(value);
-  const [selectId, setSelectId] = useState<number | null>(null);
+  const [selected, setSelected] = useState<AladinItemType | null>(null);
+  const [result, setResult] = useState<AladinItemType[] | null>();
+  const { setBook } = useWriteStore();
+  useEffect(() => {
+    const debounce = setTimeout(() => {
+      if (newValue) {
+        searchBook(newValue).then((data) => {
+          setResult(data.item);
+        });
+      }
+    }, 500);
 
-  function handleClickBook(value: number) {
-    setSelectId(value);
+    return () => clearTimeout(debounce);
+  }, [newValue]);
+
+  function handleClickBook(value: AladinItemType) {
+    setSelected(value);
   }
 
   function handleNewValueChange(e: React.ChangeEvent<HTMLInputElement>) {
     setNewValue(e.target.value);
   }
   function handleChooseBook() {
-    onClose();
+    if (selected) {
+      const {
+        isbn13: isbn,
+        title,
+        author,
+        description,
+        priceStandard,
+        cover: originCover,
+        pubDate: originPubDate,
+      } = selected;
+      const cover = originCover.replace(/cover[^/]+/, 'cover500');
+      const pubDate = formatDate(originPubDate);
+
+      setBook({
+        isbn,
+        title,
+        author,
+        description,
+        priceStandard,
+        cover,
+        pubDate,
+      });
+      onClose();
+    }
   }
   return (
     <ModalContent>
@@ -36,19 +75,23 @@ const SearchModalContent = ({ value, onClose }: SearchModalContentProps) => {
         />
       </SearchBarWrapper>
       <BookListWrapper>
-        {data.item.map((item, idx) => (
-          <BookItemWrapper
-            key={item.itemId}
-            onClick={() => handleClickBook(item.itemId)}
-            $isSelected={selectId === item.itemId}>
-            <BookImage src={item.cover} />
-            <div style={{ width: '100%' }}>
-              <TitleText>{item.title}</TitleText>
-              <InfoText>{item.author}</InfoText>
-              <InfoText>{item.pubDate}</InfoText>
-            </div>
-          </BookItemWrapper>
-        ))}
+        {result && result.length > 0 ? (
+          result.map((item) => (
+            <BookItemWrapper
+              key={item.itemId}
+              onClick={() => handleClickBook(item)}
+              $isSelected={selected?.itemId === item.itemId}>
+              <BookImage src={item.cover} />
+              <div style={{ width: '100%' }}>
+                <TitleText>{item.title}</TitleText>
+                <InfoText>{item.author}</InfoText>
+                <InfoText>{item.pubDate}</InfoText>
+              </div>
+            </BookItemWrapper>
+          ))
+        ) : (
+          <EmptyMessage>검색 결과가 없습니다.</EmptyMessage>
+        )}
       </BookListWrapper>
       <ButtonWrapper>
         <Button text='선택 완료' variant='primary' onClick={handleChooseBook} />
@@ -120,3 +163,11 @@ const InfoText = styled.div`
 `;
 
 const TitleText = styled.div``;
+
+const EmptyMessage = styled.div`
+  width: 100%;
+  text-align: center;
+  margin: 20px 0;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.GRAY_600};
+`;


### PR DESCRIPTION
### #️⃣연관된 이슈
> #63 

### 📜 작업 내용
- [x] 알라딘 open api 호출용 API Route 구현
- [x] 내부 api 함수 작성
- [x] 책 검색 기능 구현
- [x] 선택한 책 정보 zustand로 관리 - 제목에 반영

### 📄 참고
클라이언트 단에서 알라딘 api를 호출했을 때 CORS가 발생해, next js를 활용할 겸 API Route를 작성해 사용했습니다.

### ⚠️ 종료할 이슈
this closes #63 
