### PR TITLE
feat#40: 채팅방 UI 구현

### DIFF
--- a/src/app/chats/[id]/page.tsx
+++ b/src/app/chats/[id]/page.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
-import { ChatList } from '@/features/chat/ui';
 import { useIsMobile } from '@/shared/model';
+import ChatRoom from '@/features/chat/ui/ChatRoom';
 
-const ChatPage = () => {
+const ChatRoomPage = () => {
   const isMobile = useIsMobile();
   const router = useRouter();
 
@@ -21,15 +21,15 @@ const ChatPage = () => {
 
   return (
     <Container>
-      <ChatList />
+      <ChatRoom />
     </Container>
   );
 };
 
-export default ChatPage;
+export default ChatRoomPage;
 
 const Container = styled.div`
   width: 100%;
-  height: calc(100vh - 60px);
-  overflow-y: auto;
+  height: 100vh;
+  overflow: hidden;
 `;

--- a/src/features/chat/ui/ChatImages.tsx
+++ b/src/features/chat/ui/ChatImages.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import ModalCarousel from '@/features/listing/ui/detail/ModalCarousel';
+import { DetailImage } from '@/entities/listing';
+import { colors } from '@/shared/constants';
+import * as S from './ChatRoom.styles';
+
+const ChatImages = ({ images }: { images: DetailImage[] }) => {
+  const sortedImages = [...images].sort((a, b) => a.sequence - b.sequence);
+
+  const topImages = images.length > 3 ? sortedImages.slice(0, 3) : sortedImages;
+  const restCount = images.length > 3 ? images.length - 3 : 0;
+  const [isOpen, setIsOpen] = useState(false);
+  function handleShowAllImages() {
+    setIsOpen(true);
+  }
+  return (
+    <Container>
+      <S.ImageGrid onClick={handleShowAllImages}>
+        {topImages.map((img, idx) => (
+          <div key={img.sequence} style={{ position: 'relative' }}>
+            <S.ImageThumbnail src={img.fileName} />
+            {idx === 2 && (
+              <S.ImageOverlay>
+                <S.OverlayText>+{restCount}</S.OverlayText>
+              </S.ImageOverlay>
+            )}
+          </div>
+        ))}
+      </S.ImageGrid>
+      {isOpen && (
+        <ModalCarousel
+          images={images}
+          initialIndex={0}
+          onClose={() => setIsOpen(false)}
+        />
+      )}
+    </Container>
+  );
+};
+export default ChatImages;
+
+export const Container = styled.div`
+  position: relative;
+  max-width: 60%;
+
+  .swiper {
+    width: 100%;
+    height: 100%;
+  }
+
+  .swiper-slide {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .swiper-button-prev,
+  .swiper-button-next {
+    width: 40px;
+    height: 40px;
+    background-color: rgba(0, 0, 0, 0.3);
+    border-radius: 50%;
+    z-index: ${({ theme }) => theme.zIndex.button};
+    color: ${colors.light.WHITE};
+
+    &::after {
+      font-size: 16px;
+      color: ${colors.light.WHITE};
+    }
+  }
+
+  .swiper-button-prev {
+    left: 16px;
+  }
+
+  .swiper-button-next {
+    right: 16px;
+  }
+`;

--- a/src/features/chat/ui/ChatList.tsx
+++ b/src/features/chat/ui/ChatList.tsx
@@ -1,11 +1,32 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useChatWidgetStore } from '@/shared/model';
 import { data } from '@/mocks/mockChatList';
 import ChatListItem from './ChatListItem';
 
 const ChatList = () => {
+  const router = useRouter();
+  const isOpen = useChatWidgetStore((s) => s.isOpen);
+  const setShow = useChatWidgetStore((s) => s.setShow);
+  const setChatId = useChatWidgetStore((s) => s.setChatId);
+
+  function handleClickChat(id: number | null) {
+    if (isOpen) {
+      setShow('ROOM');
+      setChatId(id);
+    } else {
+      if (id !== null) router.push(`/chats/${id}`);
+    }
+  }
   return (
     <div>
       {data.map((chat, idx) => (
-        <ChatListItem key={chat.chatroomId} data={chat} />
+        <ChatListItem
+          key={chat.chatroomId}
+          data={chat}
+          onClick={handleClickChat}
+        />
       ))}
     </div>
   );

--- a/src/features/chat/ui/ChatListItem.tsx
+++ b/src/features/chat/ui/ChatListItem.tsx
@@ -7,9 +7,15 @@ import { ChatListProps } from '@/entities/chat/types';
 import { convertDiffToString } from '@/shared/lib';
 import Badge from '@/shared/ui/Badge';
 
-const ChatListItem = ({ data }: { data: ChatListProps }) => {
+const ChatListItem = ({
+  data,
+  onClick,
+}: {
+  data: ChatListProps;
+  onClick: (e: number | null) => void;
+}) => {
   return (
-    <Container>
+    <Container onClick={() => onClick(data.chatroomId)}>
       <LeftSection>
         <ImagesWrapper>
           <ProfileWrapper>

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   margin: 10px 0;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
 `;
@@ -76,12 +78,12 @@ export const TitleText = styled.div`
 `;
 
 export const Chats = styled.div`
+  flex: 1;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 10px;
-  overflow-y: scroll;
-  height: 70%;
 `;
 
 export const NoticeWrapper = styled.div`
@@ -110,6 +112,7 @@ export const ReceiveChat = styled.div`
   padding: 8px 12px;
   border-radius: 16px 16px 16px 0;
   max-width: 60%;
+  display: inline-block;
 `;
 
 export const SendChatWrapper = styled.div`
@@ -125,6 +128,40 @@ export const SendChat = styled.div`
   padding: 8px 12px;
   border-radius: 16px 16px 0 16px;
   max-width: 60%;
+`;
+
+export const ImageGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+  gap: 4px;
+  position: relative;
+  cursor: pointer;
+`;
+
+export const ImageThumbnail = styled.img`
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 5px;
+`;
+
+export const ImageOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+`;
+
+export const OverlayText = styled.div`
+  color: white;
+  font-weight: 600;
+  font-size: 20px;
 `;
 
 export const MessageInfo = styled.div``;
@@ -144,13 +181,12 @@ export const TimeText = styled.div`
 
 export const InputSection = styled.div`
   width: 100%;
-  position: absolute;
-  bottom: 0;
   padding: 10px;
   display: flex;
   align-items: center;
   margin-bottom: 5px;
   background-color: ${({ theme }) => theme.colors.WHITE};
+  min-height: 60px;
 `;
 
 export const InputWrapper = styled.div`

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -84,6 +84,22 @@ export const Chats = styled.div`
   flex-direction: column;
   gap: 8px;
   padding: 10px;
+
+  &::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => `${theme.colors.GRAY_300}`};
+    border-radius: 5px;
+    border-right: 1px solid transparent;
+    background-clip: padding-box;
+    box-sizing: border-box;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background-color: ${({ theme }) => `${theme.colors.GRAY_500}`};
+  }
 `;
 
 export const NoticeWrapper = styled.div`

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -12,6 +12,7 @@ export const Header = styled.div`
   display: flex;
   margin: 5px 10px;
   justify-content: space-between;
+  position: relative;
 `;
 
 export const IconWrapper = styled.div`
@@ -20,6 +21,7 @@ export const IconWrapper = styled.div`
   align-items: center;
   width: 40px;
   height: 40px;
+  cursor: pointer;
 `;
 
 export const Nickname = styled.div`
@@ -28,6 +30,45 @@ export const Nickname = styled.div`
   align-items: center;
   font-weight: 600;
   font-size: 18px;
+  cursor: pointer;
+`;
+
+export const Overlay = styled.div`
+  margin-top: 10px;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: ${({ theme }) => theme.zIndex.overlay};
+`;
+
+export const DropdownList = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: ${({ theme }) => theme.colors.WHITE};
+  border-radius: 10px;
+  box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
+  z-index: ${({ theme }) => theme.zIndex.overlay};
+`;
+
+export const DropdownItem = styled.div<{ $red: boolean }>`
+  padding: 5px;
+  cursor: pointer;
+  border-radius: 5px;
+  margin: 5px;
+  font-size: 13px;
+  gap: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${({ $red, theme }) =>
+    $red ? theme.colors.ERROR : theme.colors.BLACK};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.GRAY_300};
+  }
 `;
 
 export const Info = styled.div`

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -39,7 +39,7 @@ export const Overlay = styled.div`
   width: 100%;
   height: 100%;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.3);
   z-index: ${({ theme }) => theme.zIndex.overlay};
 `;
 
@@ -50,10 +50,10 @@ export const DropdownList = styled.div`
   background-color: ${({ theme }) => theme.colors.WHITE};
   border-radius: 10px;
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.2);
-  z-index: ${({ theme }) => theme.zIndex.overlay};
+  z-index: ${({ theme }) => theme.zIndex.overlay + 1};
 `;
 
-export const DropdownItem = styled.div<{ $red: boolean }>`
+export const DropdownItem = styled.div<{ $red?: boolean }>`
   padding: 5px;
   cursor: pointer;
   border-radius: 5px;
@@ -61,8 +61,9 @@ export const DropdownItem = styled.div<{ $red: boolean }>`
   font-size: 13px;
   gap: 5px;
   display: flex;
-  justify-content: center;
+  justify-content: left;
   align-items: center;
+  white-space: nowrap;
   color: ${({ $red, theme }) =>
     $red ? theme.colors.ERROR : theme.colors.BLACK};
 
@@ -96,6 +97,7 @@ export const InfoBottom = styled.div`
 
 export const Status = styled.div<{ $clickable: boolean }>`
   display: flex;
+  position: relative;
   justify-content: center;
   align-items: center;
   margin-right: 5px;

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -1,0 +1,132 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  margin: 10px 0;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  margin: 0 10px;
+  justify-content: space-between;
+`;
+
+export const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+`;
+
+export const Nickname = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 18px;
+`;
+
+export const Info = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 10px;
+  gap: 10px;
+`;
+
+export const ImageWrapper = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  overflow: hidden;
+`;
+
+export const InfoTop = styled.div`
+  display: flex;
+`;
+
+export const InfoBottom = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+export const Status = styled.div<{ $clickable: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 5px;
+  ${({ $clickable }) => $clickable && 'cursor: pointer;'}
+`;
+
+export const StatusText = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const TitleText = styled.div`
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 200px;
+`;
+
+export const Chats = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+`;
+
+export const NoticeWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export const DateText = styled.div`
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  font-weight: 500;
+  font-size: 11px;
+  padding: 2px 12px;
+  border-radius: 20px;
+`;
+
+export const ReceiveChatWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: end;
+  gap: 5px;
+`;
+
+export const ReceiveChat = styled.div`
+  background-color: ${({ theme }) => theme.colors.GRAY_300};
+  color: ${({ theme }) => theme.colors.BLACK};
+  padding: 8px 12px;
+  border-radius: 16px 16px 16px 0;
+  max-width: 60%;
+`;
+
+export const SendChatWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: end;
+  gap: 5px;
+`;
+
+export const SendChat = styled.div`
+  background-color: ${({ theme }) => theme.colors.SENDCHAT_BACK};
+  color: ${({ theme }) => theme.colors.SENDCHAT_TEXT};
+  padding: 8px 12px;
+  border-radius: 16px 16px 0 16px;
+  max-width: 60%;
+`;
+
+export const TimeText = styled.div`
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  font-size: 11px;
+  margin-bottom: 5px;
+`;
+
+export const Input = styled.div``;

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   margin: 10px 0;
+  width: 100%;
+  height: 100%;
 `;
 
 export const Header = styled.div`
@@ -78,6 +80,8 @@ export const Chats = styled.div`
   flex-direction: column;
   gap: 8px;
   padding: 10px;
+  overflow-y: scroll;
+  height: 70%;
 `;
 
 export const NoticeWrapper = styled.div`
@@ -123,10 +127,66 @@ export const SendChat = styled.div`
   max-width: 60%;
 `;
 
+export const MessageInfo = styled.div``;
+
+export const UnreadText = styled.div`
+  color: ${({ theme }) => theme.colors.PRIMARY};
+  font-size: 11px;
+  font-weight: 600;
+  text-align: end;
+`;
+
 export const TimeText = styled.div`
   color: ${({ theme }) => theme.colors.GRAY_600};
   font-size: 11px;
   margin-bottom: 5px;
 `;
 
-export const Input = styled.div``;
+export const InputSection = styled.div`
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+  background-color: ${({ theme }) => theme.colors.WHITE};
+`;
+
+export const InputWrapper = styled.div`
+  width: 100%;
+  flex: 1;
+  margin: 0 10px;
+  padding-right: 8px;
+  border: 1px ${({ theme }) => theme.colors.GRAY_400} solid;
+  border-radius: 15px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  flex: 1;
+  border: none;
+  outline: none;
+  padding: 12px;
+  font-size: 14px;
+  color: ${({ theme }) => theme.colors.BLACK};
+  background-color: transparent;
+  caret-color: ${({ theme }) => theme.colors.BLACK};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.GRAY_500};
+  }
+
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    -webkit-text-fill-color: ${({ theme }) => theme.colors.BLACK};
+    -webkit-box-shadow: 0 0 0px 1000px ${({ theme }) => theme.colors.WHITE}
+      inset;
+    box-shadow: 0 0 0px 1000px ${({ theme }) => theme.colors.WHITE} inset;
+    transition: background-color 5000s ease-in-out 0s;
+  }
+`;

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  margin-top: 10px;
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  margin: 10px 0;
+  margin-top: 10px;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -10,7 +10,7 @@ export const Container = styled.div`
 
 export const Header = styled.div`
   display: flex;
-  margin: 0 10px;
+  margin: 5px 10px;
   justify-content: space-between;
 `;
 

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import Image from 'next/image';
 import { useTheme } from 'styled-components';
+import React, { useEffect, useRef } from 'react';
 import {
   AddIcon,
   ArrowBackIcon,
@@ -158,6 +158,11 @@ const ChatRoom = () => {
   const theme = useTheme();
   const { data } = useMyQuery();
   const isSeller = data.memberId === chatData.post.sellerId;
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+  }, [chats.messages.length]);
 
   function handleClickStatus() {
     console.log('click');
@@ -212,6 +217,7 @@ const ChatRoom = () => {
       <Div />
       <S.Chats>
         {chats.messages.map((chat, idx) => {
+          const isLast = idx === chats.messages.length - 1;
           const prev = idx > 0 ? chats.messages[idx - 1].sentAt : null;
           const isNewDate = !prev || compareDate(chat.sentAt, prev);
 
@@ -244,6 +250,7 @@ const ChatRoom = () => {
                   <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
                 </S.ReceiveChatWrapper>
               )}
+              {isLast && <div ref={bottomRef} />}
             </React.Fragment>
           );
         })}

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { useTheme } from 'styled-components';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   AddIcon,
   ArrowBackIcon,
@@ -159,9 +159,17 @@ const ChatRoom = () => {
   const { data } = useMyQuery();
   const isSeller = data.memberId === chatData.post.sellerId;
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const [hasMounted, setHasMounted] = useState(false);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+    const behavior = hasMounted ? 'smooth' : 'auto';
+
+    const timer = setTimeout(() => {
+      bottomRef.current?.scrollIntoView({ behavior });
+      setHasMounted(true);
+    }, 0);
+
+    return () => clearTimeout(timer);
   }, [chats.messages.length]);
 
   function handleClickStatus() {

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/shared/lib';
 import { useMyQuery } from '@/entities/user';
 import * as S from './ChatRoom.styles';
+import ChatImages from './ChatImages';
 import { Div } from './ChatWidget';
 const chats = {
   messages: [
@@ -26,12 +27,68 @@ const chats = {
       images: [
         {
           sequence: 0,
-          fileName: 'chat/01980c81-0c31-769e-8905-f0af3854bc90.png',
+          fileName:
+            'https://i.namu.wiki/i/d1A_wD4kuLHmOOFqJdVlOXVt1TWA9NfNt_HA0CS0Y_N0zayUAX8olMuv7odG2FiDLDQZIRBqbPQwBSArXfEJlQ.webp',
+        },
+        {
+          sequence: 1,
+          fileName:
+            'https://mblogthumb-phinf.pstatic.net/MjAyMjA4MTBfMTg0/MDAxNjYwMTMyNTMzMjIx.txtlu-ga_7shsZhURoPuzfBeynckAa6ZuO_-o8rVbyUg.SobnP3coSZE-dKunc14ixPkeNmNi9LaDDOBblXnlGe0g.JPEG.happppy_/Screenshot%EF%BC%BF20220809%EF%BC%8D215510%EF%BC%BFInstagram.jpg?type=w800',
+        },
+        {
+          sequence: 2,
+          fileName:
+            'https://cdn.metavv.com/prod/uploads/thumbnail/images/10043263/167100535142741_md.png',
+        },
+        {
+          sequence: 3,
+          fileName:
+            'https://i.namu.wiki/i/qI0H3qHP6SMune3aF0Fmmu7j3q2a0kj613ndeUyB1aANfPy2I-J3bHNnMxIYCedb7YZXht0v4e6EFEjxIjTg5g.webp',
+        },
+        {
+          sequence: 4,
+          fileName:
+            'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTywyeS_VSiGo_DOI5jOAZHGoLPGNvTQYhTKA&s',
         },
       ],
       sentAt: '2025-07-14T14:16:01.05171',
       isRead: true,
       isMine: false,
+    },
+    {
+      id: 8,
+      type: 'IMAGE',
+      content: null,
+      images: [
+        {
+          sequence: 0,
+          fileName:
+            'https://i.namu.wiki/i/d1A_wD4kuLHmOOFqJdVlOXVt1TWA9NfNt_HA0CS0Y_N0zayUAX8olMuv7odG2FiDLDQZIRBqbPQwBSArXfEJlQ.webp',
+        },
+        {
+          sequence: 1,
+          fileName:
+            'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTywyeS_VSiGo_DOI5jOAZHGoLPGNvTQYhTKA&s',
+        },
+      ],
+      sentAt: '2025-07-14T14:16:01.05171',
+      isRead: true,
+      isMine: false,
+    },
+    {
+      id: 10,
+      type: 'IMAGE',
+      content: null,
+      images: [
+        {
+          sequence: 0,
+          fileName:
+            'https://i.namu.wiki/i/d1A_wD4kuLHmOOFqJdVlOXVt1TWA9NfNt_HA0CS0Y_N0zayUAX8olMuv7odG2FiDLDQZIRBqbPQwBSArXfEJlQ.webp',
+        },
+      ],
+      sentAt: '2025-07-14T14:16:01.05171',
+      isRead: true,
+      isMine: true,
     },
     {
       id: 11,
@@ -45,7 +102,7 @@ const chats = {
     {
       id: 9,
       type: 'MESSAGE',
-      content: '메시지2',
+      content: '메시지2 아니이게메세지가 길어지면 오른쪽으로 길어지지 않냐',
       images: [],
       sentAt: '2025-07-15T10:49:04.484982',
       isRead: true,
@@ -171,11 +228,19 @@ const ChatRoom = () => {
                     {!chat.isRead && <S.UnreadText>1</S.UnreadText>}
                     <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
                   </S.MessageInfo>
-                  <S.SendChat>{chat.content}</S.SendChat>
+                  {chat.type === 'IMAGE' ? (
+                    <ChatImages images={chat.images} />
+                  ) : (
+                    <S.SendChat>{chat.content}</S.SendChat>
+                  )}
                 </S.SendChatWrapper>
               ) : (
                 <S.ReceiveChatWrapper>
-                  <S.ReceiveChat>{chat.content}</S.ReceiveChat>
+                  {chat.type === 'IMAGE' ? (
+                    <ChatImages images={chat.images} />
+                  ) : (
+                    <S.ReceiveChat>{chat.content}</S.ReceiveChat>
+                  )}
                   <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
                 </S.ReceiveChatWrapper>
               )}

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,19 +1,14 @@
 import Image from 'next/image';
 import { useTheme } from 'styled-components';
 import React, { useEffect, useRef, useState } from 'react';
-import {
-  AddIcon,
-  ArrowBackIcon,
-  ChatMeatballsIcon,
-  DropdownIcon,
-  SendIcon,
-} from '@/shared/assets/icons';
+import { AddIcon, DropdownIcon, SendIcon } from '@/shared/assets/icons';
 import {
   chatPostStatusMap,
   compareDate,
   formatDate,
   formatTime,
 } from '@/shared/lib';
+import ChatRoomHeader from './ChatRoomHeader';
 import { useMyQuery } from '@/entities/user';
 import * as S from './ChatRoom.styles';
 import ChatImages from './ChatImages';
@@ -160,6 +155,7 @@ const ChatRoom = () => {
   const isSeller = data.memberId === chatData.post.sellerId;
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const [hasMounted, setHasMounted] = useState(false);
+  const [isOpenMenu, setIsOpenMenu] = useState(false);
 
   useEffect(() => {
     const behavior = hasMounted ? 'smooth' : 'auto';
@@ -172,6 +168,9 @@ const ChatRoom = () => {
     return () => clearTimeout(timer);
   }, [chats.messages.length]);
 
+  function handleCloseMenu() {
+    setIsOpenMenu(false);
+  }
   function handleClickStatus() {
     console.log('click');
   }
@@ -184,15 +183,13 @@ const ChatRoom = () => {
 
   return (
     <S.Container>
-      <S.Header>
-        <S.IconWrapper>
-          <ArrowBackIcon stroke={theme.colors.BLACK} strokeWidth={2} />
-        </S.IconWrapper>
-        <S.Nickname>{chatData.partner.nickname}</S.Nickname>
-        <S.IconWrapper>
-          <ChatMeatballsIcon stroke={theme.colors.BLACK} strokeWidth={2} />
-        </S.IconWrapper>
-      </S.Header>
+      {isOpenMenu && <S.Overlay onClick={handleCloseMenu} />}
+      <ChatRoomHeader
+        id={chatData.chatroomId}
+        partner={chatData.partner}
+        isOpenMenu={isOpenMenu}
+        onClick={() => setIsOpenMenu(true)}
+      />
       <Div />
       <S.Info>
         <S.ImageWrapper>

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import Image from 'next/image';
-import styled, { useTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
 import {
   ArrowBackIcon,
   ChatMeatballsIcon,
   DropdownIcon,
 } from '@/shared/assets/icons';
-import { compareDate, formatDate, formatTime } from '@/shared/lib';
+import {
+  chatPostStatusMap,
+  compareDate,
+  formatDate,
+  formatTime,
+} from '@/shared/lib';
 import { useMyQuery } from '@/entities/user';
+import * as S from './ChatRoom.styles';
 import { Div } from './ChatWidget';
 const chats = {
   result: [
@@ -73,7 +79,7 @@ const chatData = {
     nickname: 'manager',
     profileUrl: null,
   },
-};
+} as const;
 
 const ChatRoom = () => {
   const theme = useTheme();
@@ -83,20 +89,21 @@ const ChatRoom = () => {
   const handleClickStatus = () => {
     console.log('click');
   };
+
   return (
-    <Container>
-      <Header>
-        <IconWrapper>
+    <S.Container>
+      <S.Header>
+        <S.IconWrapper>
           <ArrowBackIcon stroke={theme.colors.BLACK} strokeWidth={2} />
-        </IconWrapper>
-        <Nickname>{chatData.partner.nickname}</Nickname>
-        <IconWrapper>
+        </S.IconWrapper>
+        <S.Nickname>{chatData.partner.nickname}</S.Nickname>
+        <S.IconWrapper>
           <ChatMeatballsIcon stroke={theme.colors.BLACK} strokeWidth={2} />
-        </IconWrapper>
-      </Header>
+        </S.IconWrapper>
+      </S.Header>
       <Div />
-      <Info>
-        <ImageWrapper>
+      <S.Info>
+        <S.ImageWrapper>
           <Image
             loader={() => chatData.post.thumbnailUrl}
             src={chatData.post.thumbnailUrl}
@@ -105,22 +112,26 @@ const ChatRoom = () => {
             height={40}
             unoptimized
           />
-        </ImageWrapper>
+        </S.ImageWrapper>
         <div>
-          <InfoTop>
-            <Status
+          <S.InfoTop>
+            <S.Status
               onClick={isSeller ? handleClickStatus : undefined}
               $clickable={isSeller}>
-              <StatusText>거래완료</StatusText>
-              {isSeller && <DropdownIcon />}
-            </Status>
-            <TitleText>{chatData.post.title}</TitleText>
-          </InfoTop>
-          <InfoBottom>{chatData.post.sellPrice.toLocaleString()}원</InfoBottom>
+              <S.StatusText>
+                {chatPostStatusMap[chatData.post.status]}
+              </S.StatusText>
+              {isSeller && <DropdownIcon fill={theme.colors.BLACK} />}
+            </S.Status>
+            <S.TitleText>{chatData.post.title}</S.TitleText>
+          </S.InfoTop>
+          <S.InfoBottom>
+            {chatData.post.sellPrice.toLocaleString()}원
+          </S.InfoBottom>
         </div>
-      </Info>
+      </S.Info>
       <Div />
-      <Chats>
+      <S.Chats>
         {chats.result.map((chat, idx) => {
           const prev = idx > 0 ? chats.result[idx - 1].sentAt : null;
           const isNewDate = !prev || compareDate(chat.sentAt, prev);
@@ -128,158 +139,28 @@ const ChatRoom = () => {
           return (
             <React.Fragment key={chat.messageId}>
               {isNewDate && (
-                <NoticeWrapper>
-                  <DateText>{formatDate(chat.sentAt)}</DateText>
-                </NoticeWrapper>
+                <S.NoticeWrapper>
+                  <S.DateText>{formatDate(chat.sentAt)}</S.DateText>
+                </S.NoticeWrapper>
               )}
-
               {chat.senderId === data.memberId ? (
-                <SendChatWrapper>
-                  <TimeText>{formatTime(chat.sentAt)}</TimeText>
-                  <SendChat>{chat.content}</SendChat>
-                </SendChatWrapper>
+                <S.SendChatWrapper>
+                  <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
+                  <S.SendChat>{chat.content}</S.SendChat>
+                </S.SendChatWrapper>
               ) : (
-                <ReceiveChatWrapper>
-                  <ReceiveChat>{chat.content}</ReceiveChat>
-                  <TimeText>{formatTime(chat.sentAt)}</TimeText>
-                </ReceiveChatWrapper>
+                <S.ReceiveChatWrapper>
+                  <S.ReceiveChat>{chat.content}</S.ReceiveChat>
+                  <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
+                </S.ReceiveChatWrapper>
               )}
             </React.Fragment>
           );
         })}
-      </Chats>
-
-      <Input></Input>
-    </Container>
+      </S.Chats>
+      <S.Input />
+    </S.Container>
   );
 };
 
 export default ChatRoom;
-const Container = styled.div`
-  margin: 10px 0;
-`;
-
-const Header = styled.div`
-  display: flex;
-  margin: 0 10px;
-  justify-content: space-between;
-`;
-
-const IconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 40px;
-  height: 40px;
-`;
-
-const Nickname = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: 600;
-  font-size: 18px;
-`;
-
-const Info = styled.div`
-  display: flex;
-  align-items: center;
-  margin: 10px;
-  gap: 10px;
-`;
-
-const ImageWrapper = styled.div`
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  overflow: hidden;
-`;
-
-const InfoTop = styled.div`
-  display: flex;
-`;
-
-const InfoBottom = styled.div`
-  font-size: 14px;
-  font-weight: 600;
-`;
-const Status = styled.div<{ $clickable: boolean }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-right: 5px;
-  ${({ $clickable }) => $clickable && 'cursor: pointer;'}
-`;
-
-const StatusText = styled.div`
-  font-size: 14px;
-  font-weight: 600;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-const TitleText = styled.div`
-  font-size: 15px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 200px;
-`;
-
-const Chats = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-`;
-
-const NoticeWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
-const DateText = styled.div`
-  color: ${({ theme }) => theme.colors.GRAY_600};
-  font-weight: 500;
-  font-size: 11px;
-  padding: 2px 12px;
-  border-radius: 20px;
-`;
-
-const ReceiveChatWrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  align-items: end;
-  gap: 5px;
-`;
-
-const ReceiveChat = styled.div`
-  background-color: ${({ theme }) => theme.colors.GRAY_300};
-  color: ${({ theme }) => theme.colors.BLACK};
-  padding: 8px 12px;
-  border-radius: 16px 16px 16px 0;
-  max-width: 60%;
-`;
-
-const SendChatWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: end;
-  gap: 5px;
-`;
-
-const SendChat = styled.div`
-  background-color: ${({ theme }) => theme.colors.SENDCHAT_BACK};
-  color: ${({ theme }) => theme.colors.SENDCHAT_TEXT};
-  padding: 8px 12px;
-  border-radius: 16px 16px 0 16px;
-  max-width: 60%;
-`;
-
-const TimeText = styled.div`
-  color: ${({ theme }) => theme.colors.GRAY_600};
-  font-size: 11px;
-  margin-bottom: 5px;
-`;
-
-const Input = styled.div``;

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,0 +1,285 @@
+import React from 'react';
+import Image from 'next/image';
+import styled, { useTheme } from 'styled-components';
+import {
+  ArrowBackIcon,
+  ChatMeatballsIcon,
+  DropdownIcon,
+} from '@/shared/assets/icons';
+import { compareDate, formatDate, formatTime } from '@/shared/lib';
+import { useMyQuery } from '@/entities/user';
+import { Div } from './ChatWidget';
+const chats = {
+  result: [
+    {
+      messageId: 1001,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
+      content: '책 아직 거래 가능할까요?',
+      sentAt: '2024-03-30T13:45:00',
+    },
+    {
+      messageId: 1002,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
+      content: '책 아직 거래 가능할까요?',
+      sentAt: '2024-03-30T13:45:00',
+    },
+    {
+      messageId: 1003,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
+      content: '책 아직 거래 가능할까요?',
+      sentAt: '2024-03-30T13:45:00',
+    },
+    {
+      messageId: 1004,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
+      content: '책 아직 거래 가능할까요?',
+      sentAt: '2024-03-30T13:45:00',
+    },
+    {
+      messageId: 1005,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
+      content:
+        '책 아직 거래 가능할까요? 두 줄이 되면 어떻게 디나오 어덯더ㅓㅇ더랜ㅇ렌',
+      sentAt: '2024-03-30T13:45:00',
+    },
+    {
+      messageId: 1006,
+      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20b',
+      content: '네 가능해요!',
+      sentAt: '2024-03-31T13:46:00',
+    },
+  ],
+};
+
+const chatData = {
+  chatroomId: 1,
+  title:
+    'manager - [Real MySQL 8.0 1권 - 개발자와 DBA를 위한 MySQL 실전 가이드]',
+  trade: {
+    id: 1,
+    status: 'REQUESTED',
+  },
+  post: {
+    id: 9,
+    title: 'Real MySQL 8.0 1권 - 개발자와 DBA를 위한 MySQL 실전 가이드',
+    thumbnailUrl:
+      'https://image.aladin.co.kr/product/27848/87/cover500/k712734689_1.jpg',
+    sellPrice: 24000,
+    sellerId: '0197c5e3-5422-77d7-bf9f-81723f32f20b',
+    status: 'IN_PROGRESS',
+  },
+  partner: {
+    id: '0197ac49-d931-76ea-a6f0-30665229f9b0',
+    nickname: 'manager',
+    profileUrl: null,
+  },
+};
+
+const ChatRoom = () => {
+  const theme = useTheme();
+  const { data } = useMyQuery();
+  const isSeller = data.memberId === chatData.post.sellerId;
+
+  const handleClickStatus = () => {
+    console.log('click');
+  };
+  return (
+    <Container>
+      <Header>
+        <IconWrapper>
+          <ArrowBackIcon stroke={theme.colors.BLACK} strokeWidth={2} />
+        </IconWrapper>
+        <Nickname>{chatData.partner.nickname}</Nickname>
+        <IconWrapper>
+          <ChatMeatballsIcon stroke={theme.colors.BLACK} strokeWidth={2} />
+        </IconWrapper>
+      </Header>
+      <Div />
+      <Info>
+        <ImageWrapper>
+          <Image
+            loader={() => chatData.post.thumbnailUrl}
+            src={chatData.post.thumbnailUrl}
+            alt='책 대표사진'
+            width={40}
+            height={40}
+            unoptimized
+          />
+        </ImageWrapper>
+        <div>
+          <InfoTop>
+            <Status
+              onClick={isSeller ? handleClickStatus : undefined}
+              $clickable={isSeller}>
+              <StatusText>거래완료</StatusText>
+              {isSeller && <DropdownIcon />}
+            </Status>
+            <TitleText>{chatData.post.title}</TitleText>
+          </InfoTop>
+          <InfoBottom>{chatData.post.sellPrice.toLocaleString()}원</InfoBottom>
+        </div>
+      </Info>
+      <Div />
+      <Chats>
+        {chats.result.map((chat, idx) => {
+          const prev = idx > 0 ? chats.result[idx - 1].sentAt : null;
+          const isNewDate = !prev || compareDate(chat.sentAt, prev);
+
+          return (
+            <React.Fragment key={chat.messageId}>
+              {isNewDate && (
+                <NoticeWrapper>
+                  <DateText>{formatDate(chat.sentAt)}</DateText>
+                </NoticeWrapper>
+              )}
+
+              {chat.senderId === data.memberId ? (
+                <SendChatWrapper>
+                  <TimeText>{formatTime(chat.sentAt)}</TimeText>
+                  <SendChat>{chat.content}</SendChat>
+                </SendChatWrapper>
+              ) : (
+                <ReceiveChatWrapper>
+                  <ReceiveChat>{chat.content}</ReceiveChat>
+                  <TimeText>{formatTime(chat.sentAt)}</TimeText>
+                </ReceiveChatWrapper>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </Chats>
+
+      <Input></Input>
+    </Container>
+  );
+};
+
+export default ChatRoom;
+const Container = styled.div`
+  margin: 10px 0;
+`;
+
+const Header = styled.div`
+  display: flex;
+  margin: 0 10px;
+  justify-content: space-between;
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+`;
+
+const Nickname = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  font-size: 18px;
+`;
+
+const Info = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 10px;
+  gap: 10px;
+`;
+
+const ImageWrapper = styled.div`
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  overflow: hidden;
+`;
+
+const InfoTop = styled.div`
+  display: flex;
+`;
+
+const InfoBottom = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+`;
+const Status = styled.div<{ $clickable: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 5px;
+  ${({ $clickable }) => $clickable && 'cursor: pointer;'}
+`;
+
+const StatusText = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+const TitleText = styled.div`
+  font-size: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 200px;
+`;
+
+const Chats = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+`;
+
+const NoticeWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const DateText = styled.div`
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  font-weight: 500;
+  font-size: 11px;
+  padding: 2px 12px;
+  border-radius: 20px;
+`;
+
+const ReceiveChatWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: end;
+  gap: 5px;
+`;
+
+const ReceiveChat = styled.div`
+  background-color: ${({ theme }) => theme.colors.GRAY_300};
+  color: ${({ theme }) => theme.colors.BLACK};
+  padding: 8px 12px;
+  border-radius: 16px 16px 16px 0;
+  max-width: 60%;
+`;
+
+const SendChatWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: end;
+  gap: 5px;
+`;
+
+const SendChat = styled.div`
+  background-color: ${({ theme }) => theme.colors.SENDCHAT_BACK};
+  color: ${({ theme }) => theme.colors.SENDCHAT_TEXT};
+  padding: 8px 12px;
+  border-radius: 16px 16px 0 16px;
+  max-width: 60%;
+`;
+
+const TimeText = styled.div`
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  font-size: 11px;
+  margin-bottom: 5px;
+`;
+
+const Input = styled.div``;

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -1,15 +1,9 @@
-import Image from 'next/image';
 import { useTheme } from 'styled-components';
 import React, { useEffect, useRef, useState } from 'react';
-import { AddIcon, DropdownIcon, SendIcon } from '@/shared/assets/icons';
-import {
-  chatPostStatusMap,
-  compareDate,
-  formatDate,
-  formatTime,
-} from '@/shared/lib';
+import { compareDate, formatDate, formatTime } from '@/shared/lib';
+import { AddIcon, SendIcon } from '@/shared/assets/icons';
 import ChatRoomHeader from './ChatRoomHeader';
-import { useMyQuery } from '@/entities/user';
+import ChatRoomInfo from './ChatRoomInfo';
 import * as S from './ChatRoom.styles';
 import ChatImages from './ChatImages';
 import { Div } from './ChatWidget';
@@ -151,11 +145,10 @@ const chatData = {
 
 const ChatRoom = () => {
   const theme = useTheme();
-  const { data } = useMyQuery();
-  const isSeller = data.memberId === chatData.post.sellerId;
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const [hasMounted, setHasMounted] = useState(false);
   const [isOpenMenu, setIsOpenMenu] = useState(false);
+  const [isOpenDropdown, setIsOpenDropdown] = useState(false);
 
   useEffect(() => {
     const behavior = hasMounted ? 'smooth' : 'auto';
@@ -168,11 +161,9 @@ const ChatRoom = () => {
     return () => clearTimeout(timer);
   }, [chats.messages.length]);
 
-  function handleCloseMenu() {
+  function handleCloseOverlay() {
     setIsOpenMenu(false);
-  }
-  function handleClickStatus() {
-    console.log('click');
+    setIsOpenDropdown(false);
   }
   function handleEnterEvent(e: React.KeyboardEvent) {
     if (e.key === 'Enter') handleSendMessage();
@@ -183,7 +174,9 @@ const ChatRoom = () => {
 
   return (
     <S.Container>
-      {isOpenMenu && <S.Overlay onClick={handleCloseMenu} />}
+      {(isOpenMenu || isOpenDropdown) && (
+        <S.Overlay onClick={handleCloseOverlay} />
+      )}
       <ChatRoomHeader
         id={chatData.chatroomId}
         partner={chatData.partner}
@@ -191,34 +184,11 @@ const ChatRoom = () => {
         onClick={() => setIsOpenMenu(true)}
       />
       <Div />
-      <S.Info>
-        <S.ImageWrapper>
-          <Image
-            loader={() => chatData.post.thumbnailUrl}
-            src={chatData.post.thumbnailUrl}
-            alt='책 대표사진'
-            width={40}
-            height={40}
-            unoptimized
-          />
-        </S.ImageWrapper>
-        <div>
-          <S.InfoTop>
-            <S.Status
-              onClick={isSeller ? handleClickStatus : undefined}
-              $clickable={isSeller}>
-              <S.StatusText>
-                {chatPostStatusMap[chatData.post.status]}
-              </S.StatusText>
-              {isSeller && <DropdownIcon fill={theme.colors.BLACK} />}
-            </S.Status>
-            <S.TitleText>{chatData.post.title}</S.TitleText>
-          </S.InfoTop>
-          <S.InfoBottom>
-            {chatData.post.sellPrice.toLocaleString()}원
-          </S.InfoBottom>
-        </div>
-      </S.Info>
+      <ChatRoomInfo
+        post={chatData.post}
+        isOpenDropdown={isOpenDropdown}
+        onClick={() => setIsOpenDropdown(true)}
+      />
       <Div />
       <S.Chats>
         {chats.messages.map((chat, idx) => {

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import Image from 'next/image';
 import { useTheme } from 'styled-components';
 import {
+  AddIcon,
   ArrowBackIcon,
   ChatMeatballsIcon,
   DropdownIcon,
+  SendIcon,
 } from '@/shared/assets/icons';
 import {
   chatPostStatusMap,
@@ -16,45 +18,59 @@ import { useMyQuery } from '@/entities/user';
 import * as S from './ChatRoom.styles';
 import { Div } from './ChatWidget';
 const chats = {
-  result: [
+  messages: [
     {
-      messageId: 1001,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
-      content: '책 아직 거래 가능할까요?',
-      sentAt: '2024-03-30T13:45:00',
+      id: 85,
+      type: 'IMAGE',
+      content: null,
+      images: [
+        {
+          sequence: 0,
+          fileName: 'chat/01980c81-0c31-769e-8905-f0af3854bc90.png',
+        },
+      ],
+      sentAt: '2025-07-14T14:16:01.05171',
+      isRead: true,
+      isMine: false,
     },
     {
-      messageId: 1002,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
-      content: '책 아직 거래 가능할까요?',
-      sentAt: '2024-03-30T13:45:00',
+      id: 11,
+      type: 'MESSAGE',
+      content: '답장',
+      images: [],
+      sentAt: '2025-07-15T10:48:40.414037',
+      isRead: true,
+      isMine: true,
     },
     {
-      messageId: 1003,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
-      content: '책 아직 거래 가능할까요?',
-      sentAt: '2024-03-30T13:45:00',
+      id: 9,
+      type: 'MESSAGE',
+      content: '메시지2',
+      images: [],
+      sentAt: '2025-07-15T10:49:04.484982',
+      isRead: true,
+      isMine: false,
     },
     {
-      messageId: 1004,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
-      content: '책 아직 거래 가능할까요?',
-      sentAt: '2024-03-30T13:45:00',
+      id: 12,
+      type: 'MESSAGE',
+      content: '답장2',
+      images: [],
+      sentAt: '2025-07-15T10:52:40.414037',
+      isRead: false,
+      isMine: true,
     },
     {
-      messageId: 1005,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20a',
-      content:
-        '책 아직 거래 가능할까요? 두 줄이 되면 어떻게 디나오 어덯더ㅓㅇ더랜ㅇ렌',
-      sentAt: '2024-03-30T13:45:00',
-    },
-    {
-      messageId: 1006,
-      senderId: '0197c5e3-5422-77d7-bf9f-81723f32f20b',
-      content: '네 가능해요!',
-      sentAt: '2024-03-31T13:46:00',
+      id: 13,
+      type: 'MESSAGE',
+      content: '답장3',
+      images: [],
+      sentAt: '2025-07-15T10:52:40.414037',
+      isRead: false,
+      isMine: true,
     },
   ],
+  hasNext: false,
 };
 
 const chatData = {
@@ -86,9 +102,15 @@ const ChatRoom = () => {
   const { data } = useMyQuery();
   const isSeller = data.memberId === chatData.post.sellerId;
 
-  const handleClickStatus = () => {
+  function handleClickStatus() {
     console.log('click');
-  };
+  }
+  function handleEnterEvent(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') handleSendMessage();
+  }
+
+  function handleSendMessage() {}
+  function handleAddImages() {}
 
   return (
     <S.Container>
@@ -132,20 +154,23 @@ const ChatRoom = () => {
       </S.Info>
       <Div />
       <S.Chats>
-        {chats.result.map((chat, idx) => {
-          const prev = idx > 0 ? chats.result[idx - 1].sentAt : null;
+        {chats.messages.map((chat, idx) => {
+          const prev = idx > 0 ? chats.messages[idx - 1].sentAt : null;
           const isNewDate = !prev || compareDate(chat.sentAt, prev);
 
           return (
-            <React.Fragment key={chat.messageId}>
+            <React.Fragment key={chat.id}>
               {isNewDate && (
                 <S.NoticeWrapper>
                   <S.DateText>{formatDate(chat.sentAt)}</S.DateText>
                 </S.NoticeWrapper>
               )}
-              {chat.senderId === data.memberId ? (
+              {chat.isMine ? (
                 <S.SendChatWrapper>
-                  <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
+                  <S.MessageInfo>
+                    {!chat.isRead && <S.UnreadText>1</S.UnreadText>}
+                    <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
+                  </S.MessageInfo>
                   <S.SendChat>{chat.content}</S.SendChat>
                 </S.SendChatWrapper>
               ) : (
@@ -158,7 +183,23 @@ const ChatRoom = () => {
           );
         })}
       </S.Chats>
-      <S.Input />
+      <S.InputSection>
+        <AddIcon
+          stroke={theme.colors.GRAY_500}
+          strokeWidth={4}
+          strokeLinecap='round'
+          style={{ cursor: 'pointer' }}
+          onClick={handleAddImages}
+        />
+        <S.InputWrapper>
+          <S.Input onKeyDown={handleEnterEvent} />
+          <SendIcon
+            fill={theme.colors.PRIMARY}
+            style={{ cursor: 'pointer' }}
+            onClick={handleSendMessage}
+          />
+        </S.InputWrapper>
+      </S.InputSection>
     </S.Container>
   );
 };

--- a/src/features/chat/ui/ChatRoomHeader.tsx
+++ b/src/features/chat/ui/ChatRoomHeader.tsx
@@ -6,6 +6,8 @@ import {
   DeleteIcon,
 } from '@/shared/assets/icons';
 import * as S from './ChatRoom.styles';
+import { useChatWidgetStore } from '@/shared/model';
+import { useRouter } from 'next/navigation';
 
 type Partner = {
   id: string;
@@ -25,7 +27,16 @@ const ChatRoomHeader = ({
   onClick,
 }: ChatRoomHeaderProps) => {
   const theme = useTheme();
-  function handleBackClick() {}
+  const router = useRouter();
+  const isOpen = useChatWidgetStore((s) => s.isOpen);
+  const { setShow, setChatId } = useChatWidgetStore();
+
+  function handleBackClick() {
+    if (isOpen) {
+      setShow('LIST');
+      setChatId(null);
+    } else router.back();
+  }
   function handleMeatballClick() {
     onClick();
   }

--- a/src/features/chat/ui/ChatRoomHeader.tsx
+++ b/src/features/chat/ui/ChatRoomHeader.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useTheme } from 'styled-components';
+import {
+  ArrowBackIcon,
+  ChatMeatballsIcon,
+  DeleteIcon,
+} from '@/shared/assets/icons';
+import * as S from './ChatRoom.styles';
+
+type Partner = {
+  id: string;
+  nickname: string;
+  profileUrl: string | null;
+};
+interface ChatRoomHeaderProps {
+  id: number;
+  partner: Partner;
+  isOpenMenu: boolean;
+  onClick: () => void;
+}
+const ChatRoomHeader = ({
+  id,
+  partner,
+  isOpenMenu,
+  onClick,
+}: ChatRoomHeaderProps) => {
+  const theme = useTheme();
+  function handleBackClick() {}
+  function handleMeatballClick() {
+    onClick();
+  }
+  function handleExitChat() {}
+
+  function handleClickNickname() {}
+  return (
+    <S.Header>
+      <S.IconWrapper onClick={handleBackClick}>
+        <ArrowBackIcon stroke={theme.colors.BLACK} strokeWidth={2} />
+      </S.IconWrapper>
+      <S.Nickname onClick={handleClickNickname}>{partner.nickname}</S.Nickname>
+      <S.IconWrapper onClick={handleMeatballClick}>
+        <ChatMeatballsIcon stroke={theme.colors.BLACK} strokeWidth={2} />
+      </S.IconWrapper>
+      {isOpenMenu && (
+        <S.DropdownList>
+          <S.DropdownItem $red={true} onClick={handleExitChat}>
+            <DeleteIcon fill={theme.colors.ERROR} /> 채팅방 나가기
+          </S.DropdownItem>
+        </S.DropdownList>
+      )}
+    </S.Header>
+  );
+};
+
+export default ChatRoomHeader;

--- a/src/features/chat/ui/ChatRoomInfo.tsx
+++ b/src/features/chat/ui/ChatRoomInfo.tsx
@@ -21,7 +21,7 @@ interface ChatRoomInfoProps {
 const ChatRoomInfo = ({ post, isOpenDropdown, onClick }: ChatRoomInfoProps) => {
   const theme = useTheme();
   const { data } = useMyQuery();
-  const isSeller = data.memberId === post.sellerId;
+  const isSeller = data?.memberId === post.sellerId;
   function handleClickStatus() {
     onClick();
   }

--- a/src/features/chat/ui/ChatRoomInfo.tsx
+++ b/src/features/chat/ui/ChatRoomInfo.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image';
+import { useTheme } from 'styled-components';
+import { DropdownIcon } from '@/shared/assets/icons';
+import { chatPostStatusMap } from '@/shared/lib';
+import { useMyQuery } from '@/entities/user';
+import * as S from './ChatRoom.styles';
+
+type Post = {
+  id: number;
+  title: string;
+  thumbnailUrl: string;
+  sellPrice: number;
+  sellerId: string;
+  status: 'IN_PROGRESS';
+};
+interface ChatRoomInfoProps {
+  post: Post;
+  isOpenDropdown: boolean;
+  onClick: () => void;
+}
+const ChatRoomInfo = ({ post, isOpenDropdown, onClick }: ChatRoomInfoProps) => {
+  const theme = useTheme();
+  const { data } = useMyQuery();
+  const isSeller = data.memberId === post.sellerId;
+  function handleClickStatus() {
+    onClick();
+  }
+  return (
+    <S.Info>
+      <S.ImageWrapper>
+        <Image
+          loader={() => post.thumbnailUrl}
+          src={post.thumbnailUrl}
+          alt='책 대표사진'
+          width={40}
+          height={40}
+          unoptimized
+        />
+      </S.ImageWrapper>
+      <div>
+        <S.InfoTop>
+          <S.Status
+            onClick={isSeller ? handleClickStatus : undefined}
+            $clickable={isSeller}>
+            <S.StatusText>{chatPostStatusMap[post.status]}</S.StatusText>
+            {isSeller && <DropdownIcon fill={theme.colors.BLACK} />}
+            {isOpenDropdown && (
+              <S.DropdownList>
+                <S.DropdownItem>판매중</S.DropdownItem>
+                <S.DropdownItem>거래완료</S.DropdownItem>
+              </S.DropdownList>
+            )}
+          </S.Status>
+          <S.TitleText>{post.title}</S.TitleText>
+        </S.InfoTop>
+        <S.InfoBottom>{post.sellPrice.toLocaleString()}원</S.InfoBottom>
+      </div>
+    </S.Info>
+  );
+};
+export default ChatRoomInfo;

--- a/src/features/chat/ui/ChatWidget.tsx
+++ b/src/features/chat/ui/ChatWidget.tsx
@@ -1,25 +1,35 @@
 'use client';
 
+import React from 'react';
 import styled from 'styled-components';
 import { useChatWidgetStore } from '@/shared/model';
 import ChatList from './ChatList';
+import ChatRoom from './ChatRoom';
 
 const ChatWidget = () => {
   const isOpen = useChatWidgetStore((s) => s.isOpen);
+  const show = useChatWidgetStore((s) => s.show);
   if (!isOpen) return null;
   return (
     <Container>
-      <TitleText>채팅</TitleText>
-      <Div />
-      <ListWrapper>
-        <ChatList />
-      </ListWrapper>
+      {show === 'ROOM' ? (
+        <ChatRoom />
+      ) : (
+        <React.Fragment>
+          <TitleText>채팅</TitleText>
+          <Div />
+          <ListWrapper>
+            <ChatList />
+          </ListWrapper>
+        </React.Fragment>
+      )}
     </Container>
   );
 };
 export default ChatWidget;
 
 export const Container = styled.div`
+  padding-top: 5px;
   position: fixed;
   bottom: 100px;
   right: 20px;
@@ -35,6 +45,7 @@ export const Container = styled.div`
 export const TitleText = styled.div`
   padding-top: 20px;
   padding-left: 20px;
+  margin-bottom: 10px;
   font-size: 20px;
   font-weight: 600;
 `;
@@ -42,7 +53,6 @@ export const TitleText = styled.div`
 export const Div = styled.div`
   width: 100%;
   height: 1px;
-  margin-top: 10px;
   background-color: ${({ theme }) => theme.colors.GRAY_300};
 `;
 

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -27,7 +27,7 @@ const Header = () => {
     pathname?.startsWith('/login') ||
     pathname?.startsWith('/signup') ||
     pathname?.startsWith('/password') ||
-    pathname?.startsWith('/chats');
+    pathname?.startsWith('/chats/');
 
   if (hideHeader) return null;
 

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -26,7 +26,8 @@ const Header = () => {
   const hideHeader =
     pathname?.startsWith('/login') ||
     pathname?.startsWith('/signup') ||
-    pathname?.startsWith('/password');
+    pathname?.startsWith('/password') ||
+    pathname?.startsWith('/chats');
 
   if (hideHeader) return null;
 

--- a/src/features/listing/ui/detail/ModalCarousel.tsx
+++ b/src/features/listing/ui/detail/ModalCarousel.tsx
@@ -1,5 +1,10 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { useEffect } from 'react';
+import styled from 'styled-components';
 import { Navigation } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { CloseIcon } from '@/shared/assets/icons';
+import { DetailImage } from '@/entities/listing';
+import { colors } from '@/shared/constants';
 
 import 'swiper/css';
 import 'swiper/css/navigation';
@@ -10,6 +15,7 @@ interface ModalCarouselProps {
   onClose: () => void;
 }
 
+// #todo: 현재 img src가 외부 url에 맞추기 위해 설정되어 있으니 파일 API 연결 이후 다시 바꿔둬야 함
 const ModalCarousel = ({
   images,
   initialIndex,
@@ -37,7 +43,8 @@ const ModalCarousel = ({
             <SwiperSlide key={img.sequence}>
               <ImageWrapper>
                 <img
-                  src={`${process.env.NEXT_PUBLIC_S3_BASE_URL}/${img.fileName}`}
+                  // src={`${process.env.NEXT_PUBLIC_S3_BASE_URL}/${img.fileName}`}
+                  src={img.fileName}
                   alt={`Image ${img.sequence + 1}`}
                 />
               </ImageWrapper>
@@ -50,12 +57,6 @@ const ModalCarousel = ({
 };
 
 export default ModalCarousel;
-
-import styled from 'styled-components';
-import { CloseIcon } from '@/shared/assets/icons';
-import { colors } from '@/shared/constants';
-import { useEffect } from 'react';
-import { DetailImage } from '@/entities/listing';
 
 export const ModalOverlay = styled.div`
   position: fixed;

--- a/src/shared/assets/icons/add.svg
+++ b/src/shared/assets/icons/add.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 12H22"/>
+<path d="M12 2L12 22" />
+</svg>

--- a/src/shared/assets/icons/arrow-back.svg
+++ b/src/shared/assets/icons/arrow-back.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 18L9 12L15 6" stroke-width="2"/>
+</svg>

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -28,6 +28,7 @@ import RawFABDefaultIcon from './fab-default.svg';
 import RawAIIcon from './ai.svg';
 import RawBookIcon from './book.svg';
 import RawChatIcon from './chat.svg';
+import RawArrowBack from './arrow-back.svg';
 
 export const UserIcon = withIconSize(RawUserIcon);
 export const NotiIcon = withIconSize(RawNotiIcon);
@@ -63,3 +64,6 @@ export const AIIcon = withIconSize(RawAIIcon, 35);
 export const AIIconSm = withIconSize(RawAIIcon, 18);
 export const BookIcon = withIconSize(RawBookIcon, 18);
 export const ChatIcon = withIconSize(RawChatIcon, 18);
+
+export const ArrowBackIcon = withIconSize(RawArrowBack, 24);
+export const ChatMeatballsIcon = withIconSize(RawMeatballsIcon, 24);

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -29,6 +29,8 @@ import RawAIIcon from './ai.svg';
 import RawBookIcon from './book.svg';
 import RawChatIcon from './chat.svg';
 import RawArrowBack from './arrow-back.svg';
+import RawAdd from './add.svg';
+import RawSend from './send.svg';
 
 export const UserIcon = withIconSize(RawUserIcon);
 export const NotiIcon = withIconSize(RawNotiIcon);
@@ -67,3 +69,5 @@ export const ChatIcon = withIconSize(RawChatIcon, 18);
 
 export const ArrowBackIcon = withIconSize(RawArrowBack, 24);
 export const ChatMeatballsIcon = withIconSize(RawMeatballsIcon, 24);
+export const AddIcon = withIconSize(RawAdd, 20);
+export const SendIcon = withIconSize(RawSend, 18);

--- a/src/shared/assets/icons/send.svg
+++ b/src/shared/assets/icons/send.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.0095238 20L20 10L0.0095238 0L0 7.77778L14.2857 10L0 12.2222L0.0095238 20Z"/>
+</svg>

--- a/src/shared/constants/colors.ts
+++ b/src/shared/constants/colors.ts
@@ -10,6 +10,8 @@ const common = {
     MEDIUM: '#7E91A0',
     LOW: '#BDBDBD',
   },
+  SENDCHAT_BACK: '#FFE0A5',
+  SENDCHAT_TEXT: '#424242',
 };
 
 export const colors = {

--- a/src/shared/lib/date.ts
+++ b/src/shared/lib/date.ts
@@ -37,3 +37,23 @@ export function formatDate(dateString: string) {
     String(day).padStart(2, '0'),
   ].join('-');
 }
+
+export function formatTime(dateString: string) {
+  const date = new Date(dateString);
+  const hour = date.getHours();
+  const minutes = date.getMinutes();
+
+  return [hour, minutes].join(':');
+}
+
+export function compareDate(curString: string, prevString: string) {
+  const cur = new Date(curString);
+  const prev = new Date(prevString);
+  if (
+    cur.getFullYear() === prev.getFullYear() &&
+    cur.getMonth() === prev.getMonth() &&
+    cur.getDate() === prev.getDate()
+  )
+    return false;
+  return true;
+}

--- a/src/shared/lib/postTextMap.ts
+++ b/src/shared/lib/postTextMap.ts
@@ -11,6 +11,12 @@ export const bookStatusMap = {
   LOW: '하',
 } as const;
 
+export const chatPostStatusMap = {
+  READY: '판매중',
+  IN_PROGRESS: '예약중',
+  COMPLETED: '판매완료',
+} as const;
+
 export const priceRangeMap: { [key: number]: string } = {
   0: '~5,000원',
   1: '5,000원~10,000원',

--- a/src/shared/model/useChatWidgetStore.ts
+++ b/src/shared/model/useChatWidgetStore.ts
@@ -4,21 +4,24 @@ import { create } from 'zustand';
 
 interface ChatWidgetState {
   isOpen: boolean;
-  open: () => void;
-  close: () => void;
-  toggle: () => void;
+  setIsOpen: (b: boolean) => void;
+  show: 'LIST' | 'ROOM';
+  setShow: (s: 'LIST' | 'ROOM') => void;
+  chatId: number | null;
+  setChatId: (d: number | null) => void;
 }
 
 export const useChatWidgetStore = create<ChatWidgetState>((set) => ({
   isOpen: false,
-  open: () => {
-    console.log('store open() 실행');
-    set({ isOpen: true });
+  setIsOpen: (b) => {
+    set({ isOpen: b });
   },
-  close: () => set({ isOpen: false }),
-  toggle: () =>
-    set((state) => {
-      console.log('현재 isOpen 값:', state.isOpen);
-      return { isOpen: !state.isOpen };
-    }),
+  show: 'LIST',
+  setShow: (s) => {
+    set({ show: s });
+  },
+  chatId: null,
+  setChatId: (d) => {
+    set({ chatId: d });
+  },
 }));

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -62,10 +62,11 @@ const FloatingButton = () => {
     router.push('/ai');
   }
 
-  function handleClickChat() {
+  function handleClickChat(e?: React.MouseEvent) {
     if (isMobile) {
       router.push('/chats');
     } else {
+      e?.stopPropagation();
       setChatIsOpen(true);
     }
   }
@@ -113,7 +114,11 @@ const FloatingButton = () => {
                   </S.MenuItem>
                 </Link>
               ) : (
-                <S.MenuItem key={idx} onClick={item.onClick}>
+                <S.MenuItem
+                  key={idx}
+                  onClick={(e) => {
+                    item.onClick?.(e);
+                  }}>
                   <S.SmallIconWrapper>{item.icon}</S.SmallIconWrapper>
                   <span>{item.label}</span>
                   {item.badge !== undefined && (

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -29,7 +29,7 @@ const FloatingButton = () => {
   const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
   const chatIsOpen = useChatWidgetStore((s) => s.isOpen);
-  const { open, close } = useChatWidgetStore();
+  const { setIsOpen: setChatIsOpen } = useChatWidgetStore();
 
   const hideHeader =
     pathname?.startsWith('/login') ||
@@ -66,13 +66,13 @@ const FloatingButton = () => {
     if (isMobile) {
       router.push('/chats');
     } else {
-      open();
+      setChatIsOpen(true);
     }
   }
 
   function handleClickToggle() {
     setIsOpen((prev) => !prev);
-    if (chatIsOpen) close();
+    if (chatIsOpen) setChatIsOpen(false);
   }
 
   return (

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -35,8 +35,8 @@ const FloatingButton = () => {
     pathname?.startsWith('/login') ||
     pathname?.startsWith('/signup') ||
     pathname?.startsWith('/password') ||
-    pathname?.startsWith('/listings/write');
-
+    pathname?.startsWith('/listings/write') ||
+    pathname?.startsWith('/chats');
   if (hideHeader) return null;
 
   const menuItems = [


### PR DESCRIPTION
### #️⃣연관된 이슈
> #40 

### 📜 작업 내용
- [x] 채팅에서 쓸 formatTime, compareDate 함수 작성
- [x] 채팅방 스타일 파일 분리
- [x] 헤더, 정보, 말풍선, 읽음 여부 표시, 전송 시간, 날짜 UI
- [x] 채팅방 나가기, 거래 상태 변경 UI

### 🖼️ 스크린샷 (선택)
<img width="300" alt="채팅방 사진" src="https://github.com/user-attachments/assets/ba984528-9aed-47bc-bf1d-3c1c371ae571" />
<img width="300" alt="채팅방 채팅" src="https://github.com/user-attachments/assets/53cce13d-d58b-4d84-81b5-dddc700adbdb" />
<img width="300" alt="채팅방 나가기" src="https://github.com/user-attachments/assets/c90919d3-04b9-4159-9f0e-c65b5795623d" />
<img width="300" alt="거래 상태 변경" src="https://github.com/user-attachments/assets/0080b828-593e-49dd-a885-c22966f78d61" />

### 📄 참고 사항

### ⚠️ 종료할 이슈
this closes #40 
