### PR TITLE
feat#92: 로딩 및 에러 핸들링

### DIFF
--- a/src/app/chats/[id]/page.tsx
+++ b/src/app/chats/[id]/page.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/shared/model';
 import ChatRoom from '@/features/chat/ui/ChatRoom';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const ChatRoomPage = () => {
   const isMobile = useIsMobile();
@@ -21,7 +22,9 @@ const ChatRoomPage = () => {
 
   return (
     <Container>
-      <ChatRoom />
+      <LocalErrorBoundary>
+        <ChatRoom />
+      </LocalErrorBoundary>
     </Container>
   );
 };

--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/navigation';
+import { LocalErrorBoundary } from '@/shared/lib';
 import { ChatList } from '@/features/chat/ui';
 import { useIsMobile } from '@/shared/model';
 
@@ -21,7 +22,9 @@ const ChatPage = () => {
 
   return (
     <Container>
-      <ChatList />
+      <LocalErrorBoundary>
+        <ChatList />
+      </LocalErrorBoundary>
     </Container>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,10 @@ import localFont from 'next/font/local';
 import { ToastContainer } from 'react-toastify';
 import StyledComponentsRegistry from '@/shared/lib/StyledComponentsRegistry';
 import { ReactQueryClientProvider, ThemeRegistry } from '@/shared/providers';
-import { FloatingButton } from '@/shared/ui';
-import { ChatWidget } from '@/features/chat/ui';
 import { GlobalErrorBoundary } from '@/shared/lib';
+import { ChatWidget } from '@/features/chat/ui';
 import { Header } from '@/features/header/ui';
+import { FloatingButton } from '@/shared/ui';
 
 const pretendard = localFont({
   src: '../shared/assets/fonts/PretendardVariable.woff2',

--- a/src/app/listings/[id]/page.tsx
+++ b/src/app/listings/[id]/page.tsx
@@ -1,19 +1,25 @@
 'use client';
 
-import { useParams } from 'next/navigation';
 import styled from 'styled-components';
+import { useParams } from 'next/navigation';
 import { ListingDetail } from '@/features/listing/ui';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const ListingDetailPage = () => {
   const params = useParams<{ id: string }>();
   if (!params || !params.id) return null;
   return (
     <Container>
-      <ListingDetail id={Number(params.id)} />
+      <LocalErrorBoundary>
+        <ListingDetail id={Number(params.id)} />
+      </LocalErrorBoundary>
     </Container>
   );
 };
 
-const Container = styled.div``;
+const Container = styled.div`
+  width: 100%;
+  height: 100%;
+`;
 
 export default ListingDetailPage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import {
   ListingList,
 } from '@/features/listing/ui';
 import { FilterSidebar } from '@/features/listing/ui';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const Home = () => {
   return (
@@ -15,7 +16,9 @@ const Home = () => {
       <ControlsMobile />
       <div style={{ display: 'flex' }}>
         <FilterSidebar />
-        <ListingList />
+        <LocalErrorBoundary>
+          <ListingList />
+        </LocalErrorBoundary>
       </div>
     </Container>
   );

--- a/src/features/chat/ui/ChatList.tsx
+++ b/src/features/chat/ui/ChatList.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useChatQuery } from '@/entities/chat';
+import { LoadingIndicator } from '@/shared/ui';
 import { useFABStore } from '@/shared/model';
 import ChatListItem from './ChatListItem';
-import { useChatQuery } from '@/entities/chat';
 
 const ChatList = () => {
   const router = useRouter();
   const isOpen = useFABStore((s) => s.chatIsOpen);
   const setShow = useFABStore((s) => s.setShow);
   const setChatId = useFABStore((s) => s.setChatId);
-  const { data } = useChatQuery();
+  const { data, isPending } = useChatQuery();
 
   function handleClickChat(id: number | null) {
     if (isOpen) {
@@ -23,14 +24,25 @@ const ChatList = () => {
 
   return (
     <div>
-      {data &&
+      {data && !isPending ? (
         data.map((chat, idx) => (
           <ChatListItem
             key={chat.chatroomId}
             data={chat}
             onClick={handleClickChat}
           />
-        ))}
+        ))
+      ) : (
+        <div
+          style={{
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            paddingTop: 20,
+          }}>
+          <LoadingIndicator text='로딩중' />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/chat/ui/ChatWidget.tsx
+++ b/src/features/chat/ui/ChatWidget.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import styled from 'styled-components';
+import { LocalErrorBoundary } from '@/shared/lib';
 import { useFABStore } from '@/shared/model';
 import ChatList from './ChatList';
 import ChatRoom from './ChatRoom';
@@ -13,13 +14,17 @@ const ChatWidget = () => {
   return (
     <Container>
       {show === 'ROOM' ? (
-        <ChatRoom />
+        <LocalErrorBoundary>
+          <ChatRoom />
+        </LocalErrorBoundary>
       ) : (
         <React.Fragment>
           <TitleText>채팅</TitleText>
           <Div />
           <ListWrapper>
-            <ChatList />
+            <LocalErrorBoundary>
+              <ChatList />
+            </LocalErrorBoundary>
           </ListWrapper>
         </React.Fragment>
       )}

--- a/src/features/header/ui/Header.tsx
+++ b/src/features/header/ui/Header.tsx
@@ -20,7 +20,7 @@ import {
 const Header = () => {
   const mode = useThemeStore((state) => state.mode);
   const toggleMode = useThemeStore((state) => state.toggleMode);
-  const { data, isLoading, isError } = useMyQuery();
+  const { data, isPending, isError } = useMyQuery();
   const isLogin = useMyStore((s) => s.isLogin);
   const { setIsLogin } = useMyStore();
 
@@ -57,7 +57,7 @@ const Header = () => {
             <LightModeIcon fill={colors.dark.PRIMARY} />
           )}
         </div>
-        {!isLoading && isLogin ? (
+        {!isPending && isLogin ? (
           <S.IconGroup>
             <Link
               href='/my'
@@ -74,7 +74,7 @@ const Header = () => {
             </Link>
             <NotiIcon stroke={theme.colors.BLACK} strokeWidth={2} fill='none' />
           </S.IconGroup>
-        ) : !isLoading && !isLogin ? (
+        ) : !isPending && !isLogin ? (
           <S.LoginButton onClick={() => router.push('/login')}>
             로그인
           </S.LoginButton>

--- a/src/features/listing/ui/detail/ListingDetail.styles.ts
+++ b/src/features/listing/ui/detail/ListingDetail.styles.ts
@@ -236,3 +236,9 @@ export const SwiperWrapper = styled.div`
     right: 8px;
   }
 `;
+
+export const LoadingContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;

--- a/src/features/listing/ui/detail/ListingDetail.tsx
+++ b/src/features/listing/ui/detail/ListingDetail.tsx
@@ -10,6 +10,7 @@ import { calcDistance, getCategoryNameById } from '../../lib';
 import { useHandleOpenChat } from '@/shared/model';
 import { useChatMutation } from '@/entities/chat';
 import { LikeIcon } from '@/shared/assets/icons';
+import { LoadingIndicator } from '@/shared/ui';
 import { useMyQuery } from '@/entities/user';
 import { colors } from '@/shared/constants';
 import * as S from './ListingDetail.styles';
@@ -25,7 +26,7 @@ interface ListingDetailProps {
 const ListingDetail = ({ id }: ListingDetailProps) => {
   const theme = useTheme();
   const { data: mydata } = useMyQuery();
-  const { data, isLoading } = useListingDetailQuery(id);
+  const { data, isPending } = useListingDetailQuery(id);
   const [liked, setLiked] = useState<boolean | undefined>(undefined);
   const [originalLiked, setOriginalLiked] = useState<boolean | undefined>(
     undefined,
@@ -86,7 +87,7 @@ const ListingDetail = ({ id }: ListingDetailProps) => {
 
   return (
     <S.Container>
-      {data && !isLoading ? (
+      {data && !isPending ? (
         <>
           <S.LeftSection>
             <ImageCarousel
@@ -142,7 +143,9 @@ const ListingDetail = ({ id }: ListingDetailProps) => {
           </S.RightSection>
         </>
       ) : (
-        <></>
+        <S.LoadingContainer>
+          <LoadingIndicator text='불러오는중' />
+        </S.LoadingContainer>
       )}
     </S.Container>
   );

--- a/src/features/listing/ui/main/list/ListingList.tsx
+++ b/src/features/listing/ui/main/list/ListingList.tsx
@@ -67,8 +67,8 @@ const ListingList = ({
   const data = isFavorite ? favoriteData : listingData;
   const fetchNextPage = isFavorite ? fetchFavoriteNext : fetchListingNext;
   const hasNextPage = isFavorite ? hasFavoriteNext : hasListingNext;
-  const isPending = isListingPending || isFavoritePending;
-  const isError = isListingError || isFavoriteError;
+  const isPending = isFavorite ? isFavoritePending : isListingPending;
+  const isError = isFavorite ? isFavoriteError : isListingError;
 
   const listings = data?.pages.flatMap((page) => page.posts) ?? [];
   function handleLoadMore() {

--- a/src/features/listing/ui/main/list/ListingList.tsx
+++ b/src/features/listing/ui/main/list/ListingList.tsx
@@ -7,6 +7,7 @@ import {
   useListingQuery,
 } from '@/entities/listing';
 import { useFilterStore } from '@/features/listing/model';
+import { LoadingIndicator } from '@/shared/ui';
 import { useMyQuery } from '@/entities/user';
 import ListingCard from './ListingCard';
 
@@ -51,28 +52,41 @@ const ListingList = ({
     data: listingData,
     fetchNextPage: fetchListingNext,
     hasNextPage: hasListingNext,
+    isPending: isListingPending,
+    isError: isListingError,
   } = useListingQuery(filter);
 
   const {
     data: favoriteData,
     fetchNextPage: fetchFavoriteNext,
     hasNextPage: hasFavoriteNext,
+    isPending: isFavoritePending,
+    isError: isFavoriteError,
   } = useFavoritesQuery(isFavorite ? true : false);
 
   const data = isFavorite ? favoriteData : listingData;
   const fetchNextPage = isFavorite ? fetchFavoriteNext : fetchListingNext;
   const hasNextPage = isFavorite ? hasFavoriteNext : hasListingNext;
+  const isPending = isListingPending || isFavoritePending;
+  const isError = isListingError || isFavoriteError;
 
   const listings = data?.pages.flatMap((page) => page.posts) ?? [];
-
   function handleLoadMore() {
     fetchNextPage();
   }
 
   return (
     <Container>
-      {listings.length === 0 ? (
-        <EmptyMessage>판매글이 없습니다.</EmptyMessage>
+      {isPending ? (
+        <LoadingIndicator text='불러오는중' />
+      ) : isError ? (
+        <></>
+      ) : listings.length === 0 ? (
+        <EmptyMessage>
+          판매글이 없습니다.
+          <br />
+          판매글을 올려 보세요!
+        </EmptyMessage>
       ) : (
         <ListWrapper>
           {listings.map((listing) => (
@@ -97,6 +111,7 @@ export const Container = styled.div`
   height: 90%;
 `;
 export const EmptyMessage = styled.div`
+  text-align: center;
   font-weight: 500;
   color: ${({ theme }) => theme.colors.GRAY_600};
 `;

--- a/src/features/user/ui/MyBook.tsx
+++ b/src/features/user/ui/MyBook.tsx
@@ -1,9 +1,12 @@
 import { ListingList } from '@/features/listing/ui';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const MyBook = () => {
   return (
     <div style={{ width: '100%' }}>
-      <ListingList isUserPage={true} />
+      <LocalErrorBoundary>
+        <ListingList isUserPage={true} />
+      </LocalErrorBoundary>
     </div>
   );
 };

--- a/src/features/user/ui/MyFavorite.tsx
+++ b/src/features/user/ui/MyFavorite.tsx
@@ -1,9 +1,12 @@
 import { ListingList } from '@/features/listing/ui';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const MyFavorite = () => {
   return (
     <div style={{ width: '100%' }}>
-      <ListingList isFavorite={true} />
+      <LocalErrorBoundary>
+        <ListingList isFavorite={true} />
+      </LocalErrorBoundary>
     </div>
   );
 };

--- a/src/features/user/ui/UserProfile.tsx
+++ b/src/features/user/ui/UserProfile.tsx
@@ -6,11 +6,12 @@ import { ListingList } from '@/features/listing/ui';
 import { useMediaQuery } from '@/shared/model';
 import { useUserQuery } from '@/entities/user';
 import { getAreaNameById } from '../lib';
+import { LocalErrorBoundary } from '@/shared/lib';
 
 const UserProfile = ({ id }: { id: string }) => {
   const isMobile = useMediaQuery(`(max-width: 393px)`);
   const profileWidth = useMemo(() => (isMobile ? 50 : 80), [isMobile]);
-  const { data, isPending, isError } = useUserQuery(id);
+  const { data } = useUserQuery(id);
 
   return (
     <Container>
@@ -33,7 +34,9 @@ const UserProfile = ({ id }: { id: string }) => {
             </div>
           </Profile>
           <BoldText>[{data.nickname}]의 판매글</BoldText>
-          <ListingList isUserPage={true} id={id} />
+          <LocalErrorBoundary>
+            <ListingList isUserPage={true} id={id} />
+          </LocalErrorBoundary>
         </>
       )}
     </Container>

--- a/src/shared/config/axios.ts
+++ b/src/shared/config/axios.ts
@@ -1,8 +1,49 @@
-import axios from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
+
+type Cfg = InternalAxiosRequestConfig & { _retry?: boolean };
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
   withCredentials: true,
 });
+
+let refreshInFlight: Promise<void> | null = null;
+const isRefresh = (url?: string) => url?.includes('/auth/token/refresh');
+
+axiosInstance.interceptors.response.use(
+  (r) => r,
+  async (error) => {
+    if (!error.response) return Promise.reject(error);
+
+    const code = error.response.data?.code as string | undefined;
+    const cfg = (error.config || {}) as Cfg;
+
+    if (isRefresh(cfg.url) || cfg._retry) return Promise.reject(error);
+
+    const nonLogin = code === 'E001';
+    const tryRefresh = code === 'E002';
+    console.log(code);
+    if (nonLogin) {
+      return;
+    } else if (!tryRefresh) {
+      return Promise.reject(error);
+    }
+
+    cfg._retry = true;
+    if (!refreshInFlight) {
+      refreshInFlight = axiosInstance.post('/auth/token/refresh').then(() => {
+        console.log('refresh');
+      });
+      refreshInFlight.finally(() => (refreshInFlight = null));
+    }
+
+    try {
+      await refreshInFlight;
+      return axiosInstance(cfg);
+    } catch {
+      return Promise.reject(error);
+    }
+  },
+);
 
 export default axiosInstance;

--- a/src/shared/lib/LocalErrorBoundary.tsx
+++ b/src/shared/lib/LocalErrorBoundary.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import styled, { useTheme } from 'styled-components';
+import { ErrorBoundary } from 'react-error-boundary';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+
+const LocalErrorBoundary = ({ children }: { children: React.ReactNode }) => {
+  const theme = useTheme();
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <Container>
+              <p>데이터를 불러오는 중 문제가 발생했습니다.</p>
+              <div
+                onClick={() => resetErrorBoundary()}
+                style={{
+                  color: theme.colors.GRAY_500,
+                  textDecoration: 'underline',
+                  cursor: 'pointer',
+                }}>
+                다시 시도
+              </div>
+            </Container>
+          )}>
+          {children}
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+};
+
+export default LocalErrorBoundary;
+
+const Container = styled.div`
+  width: 100%;
+  height: 90%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+`;

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,9 +1,16 @@
 import { getErrorDataByCode } from './getErrorDataByCode';
 import GlobalErrorBoundary from './GlobalErrorBoundary';
+import LocalErrorBoundary from './LocalErrorBoundary';
 import { withIconSize } from './withIconSize';
 import { queryClient } from './queryClient';
 export * from './postTextMap';
 export * from './date';
 export * from './cleanHtmlText';
 
-export { withIconSize, queryClient, getErrorDataByCode, GlobalErrorBoundary };
+export {
+  withIconSize,
+  queryClient,
+  getErrorDataByCode,
+  GlobalErrorBoundary,
+  LocalErrorBoundary,
+};

--- a/src/shared/model/connectNoti.ts
+++ b/src/shared/model/connectNoti.ts
@@ -23,7 +23,7 @@ export const connectNoti = (
   es.addEventListener('NOTIFICATION', (e: MessageEvent) => {
     try {
       const data = JSON.parse(e.data);
-      onNoti(data);
+      if (data.type === 'CHAT') onNoti(data);
     } catch (err) {
       console.error('파싱 실패', e.data);
     }

--- a/src/shared/ui/FallbackGlobal.tsx
+++ b/src/shared/ui/FallbackGlobal.tsx
@@ -22,7 +22,8 @@ export const FallbackGlobal = ({
 
   const errorData = getErrorDataByCode(error);
   const isLoginRequired =
-    'requireLogin' in errorData && errorData.requireLogin === true;
+    ('requireLogin' in errorData && errorData.requireLogin === true) ||
+    errorData.code === 'E003';
   return (
     <Container>
       <Wrapper>

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -53,10 +53,11 @@ const FloatingButton = () => {
   }, []);
 
   useEffect(() => {
+    if (!isLogin) return;
     connectNoti(onNoti, () => {
       console.log('error');
     });
-  }, []);
+  }, [isLogin, onNoti]);
 
   const hideButton =
     pathname?.startsWith('/login') ||
@@ -101,11 +102,7 @@ const FloatingButton = () => {
 
   function handleNoti() {
     if (!visibleNoti) return;
-    if (visibleNoti.type === 'CHAT') {
-      handleOpenChat({ chatId: visibleNoti.refId });
-    } else if (visibleNoti.type === 'TRADE') {
-      router.push(`/listings/${visibleNoti.refId}`);
-    }
+    handleOpenChat({ chatId: visibleNoti.refId });
   }
   return (
     <>


### PR DESCRIPTION
### #️⃣연관된 이슈
> #92 

### 📜 작업 내용
- [x] 인증 에러 처리(axios interceptor)
  - [x] E001: 비로그인 상태
  - [x] E002: access token 만료 상태 -> 토큰 재발급 후 재요청
  - [x] 토큰 재발급 에러 시 GlobalErrorBoundary로 넘어가 사용자에게 로그인 요청
- [x] 판매글 목록 조회, 상세 조회, 채팅 컴포넌트 상위에 LocalErrorBoundary 및 loading indicator 적용
- [x] 로그인 상태일 때만 알림 구독, type === 'CHAT'인 알림만 FAB 팝업
 


### ⚠️ 종료할 이슈
this closes #92
