### PR TITLE
feat#95: 새로고침 시 테마, 마이페이지 탭 상태 유지

### DIFF
--- a/src/features/user/ui/My.tsx
+++ b/src/features/user/ui/My.tsx
@@ -1,14 +1,27 @@
-import { useState } from 'react';
-import MyTab from './MyTab';
+'use client';
+
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import EditProfile from './EditProfile';
 import MyFavorite from './MyFavorite';
 import MyBook from './MyBook';
-import styled from 'styled-components';
+import MyTab from './MyTab';
+
+const SESSION_KEY = 'my-tab-selected';
 
 const My = () => {
   const [selected, setSelected] = useState(0);
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(SESSION_KEY);
+    if (stored !== null) {
+      setSelected(Number(stored));
+    }
+  }, []);
+
   function handleClickTab(value: number) {
     setSelected(value);
+    sessionStorage.setItem(SESSION_KEY, value.toString());
   }
   return (
     <Container>

--- a/src/shared/model/useThemeStore.ts
+++ b/src/shared/model/useThemeStore.ts
@@ -1,16 +1,22 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
-type ThemeMode = 'light' | 'dark';
-
+type Mode = 'light' | 'dark';
 interface ThemeState {
-  mode: ThemeMode;
+  mode: Mode;
   toggleMode: () => void;
 }
 
-export const useThemeStore = create<ThemeState>((set) => ({
-  mode: 'light',
-  toggleMode: () =>
-    set((state) => ({
-      mode: state.mode === 'light' ? 'dark' : 'light',
-    })),
-}));
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      mode: 'light',
+      toggleMode: () =>
+        set({ mode: get().mode === 'light' ? 'dark' : 'light' }),
+    }),
+    {
+      name: 'theme',
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/src/shared/providers/ThemeRegistry.tsx
+++ b/src/shared/providers/ThemeRegistry.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { light, dark } from '@/shared/config/theme';
 import GlobalStyle from '@/shared/styles/GlobalStyles';
@@ -10,8 +10,15 @@ export default function ThemeRegistry({
 }: {
   children: React.ReactNode;
 }) {
+  const [mounted, setMounted] = useState(false);
   const mode = useThemeStore((state) => state.mode);
   const theme = mode == 'dark' ? dark : light;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
 
   return (
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
### #️⃣연관된 이슈
> #95 

### 📜 작업 내용
- [x] 테마 상태 값 zustand persist로 관리
- [x] 마이페이지 탭 상태 session storage에 저장


### ⚠️ 종료할 이슈
this closes #95 
