### PR TITLE
feat#103: 알림 수신 및 채팅방 입장 시 unreadCount 갱신

### DIFF
--- a/src/entities/chat/api.ts
+++ b/src/entities/chat/api.ts
@@ -55,7 +55,7 @@ export const postNewMessage = async ({
   chatroomId,
   message,
   fileNames,
-}: postMessageProps): Promise<{ isRead: boolean }> => {
+}: postMessageProps) => {
   const { data } = await axiosInstance.post(
     `/chatrooms/${chatroomId}/messages`,
     { message, fileNames },

--- a/src/entities/chat/queries.ts
+++ b/src/entities/chat/queries.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { queryClient } from '@/shared/lib';
 import {
   getChatInfo,
   getChats,
@@ -29,10 +30,12 @@ export const useChatInfoQuery = (
   });
 };
 
-// #todo: 채팅 목록 refetch
 export const useExitChatMutation = () => {
   return useMutation<void, Error, number>({
     mutationFn: (data) => patchChatRoom(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chats'] });
+    },
   });
 };
 
@@ -61,7 +64,6 @@ export const useChatQuery = () => {
   });
 };
 
-// #todo: 채팅방 입장, 알림 오면 갱신
 export const useUnreadQuery = (enabled: boolean) => {
   return useQuery({
     queryKey: ['unread'],

--- a/src/entities/chat/queries.ts
+++ b/src/entities/chat/queries.ts
@@ -41,6 +41,8 @@ export const useExitChatMutation = () => {
 
 interface useMessageMutationResponse {
   isRead: boolean;
+  id: number;
+  sentAt: string;
 }
 
 export const useMessageMutate = () => {

--- a/src/entities/chat/types.ts
+++ b/src/entities/chat/types.ts
@@ -62,18 +62,24 @@ export interface getMessageResponse {
   hasNext: boolean;
 }
 
-export interface ChatMessage {
-  id?: number;
+interface BasicChat {
   type: ChatType;
   content: string | null;
   images: DetailImage[];
-  sentAt?: string;
-  isRead?: boolean;
-  isMine?: boolean;
-  isLoading?: boolean;
-  isError?: boolean;
-  clientId?: string;
+  sentAt: string;
+  isMine: boolean;
 }
+export interface ServerChat extends BasicChat {
+  id: number;
+  isRead: boolean;
+}
+export interface LocalChat extends BasicChat {
+  clientId: string;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export type ChatMessage = ServerChat | LocalChat;
 
 export interface Chat {
   chatroomId: number;

--- a/src/features/chat/model/useFailedChatStore.test.ts
+++ b/src/features/chat/model/useFailedChatStore.test.ts
@@ -10,7 +10,6 @@ describe('sendMessage 실패 흐름 테스트', () => {
 
   it('sendMessage 실패 시 실패 메시지가 store와 localStorage에 저장된다', () => {
     const mockFailedChat = {
-      id: 1,
       clientId: 'test-id',
       content: '실패 메시지',
       type: 'TEXT',
@@ -19,6 +18,7 @@ describe('sendMessage 실패 흐름 테스트', () => {
       isError: true,
       images: [] as DetailImage[],
       isRead: false,
+      sentAt: String(new Date()),
     } as const;
 
     useFailedChatStore.getState().addFailedChat(2, mockFailedChat);
@@ -35,7 +35,6 @@ describe('sendMessage 실패 흐름 테스트', () => {
   it('재전송 시 실패 메시지가 store와 localStorage에서 삭제된다', () => {
     const clientId = 'to-be-deleted';
     const failChat = {
-      id: 2,
       clientId,
       content: '삭제될 메시지',
       type: 'TEXT',
@@ -44,6 +43,7 @@ describe('sendMessage 실패 흐름 테스트', () => {
       isError: true,
       images: [] as DetailImage[],
       isRead: false,
+      sentAt: String(new Date()),
     } as const;
 
     useFailedChatStore.getState().addFailedChat(1, failChat);

--- a/src/features/chat/model/useFailedChatStore.ts
+++ b/src/features/chat/model/useFailedChatStore.ts
@@ -27,7 +27,9 @@ export const useFailedChatStore = create<FailedChatStore>()(
         set({
           failedChats: {
             ...get().failedChats,
-            [chatroomId]: prev.filter((chat) => chat.clientId !== clientId),
+            [chatroomId]: prev.filter(
+              (chat) => 'clientId' in chat && chat.clientId !== clientId,
+            ),
           },
         });
       },

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -5,6 +5,8 @@ import { compareDate, formatDate, formatTime } from '@/shared/lib';
 import {
   ChatMessage,
   connectChat,
+  LocalChat,
+  ServerChat,
   useChatInfoQuery,
   useMessageMutate,
   useMessageQuery,
@@ -37,48 +39,30 @@ const ChatRoom = () => {
   const [isOpenMenu, setIsOpenMenu] = useState(false);
   const [chats, setChats] = useState<ChatMessage[]>([]);
   const [isOpenDropdown, setIsOpenDropdown] = useState(false);
-  const [hasInitialized, setHasInitialized] = useState(false);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const chatRoomId = isMobile && params ? Number(params.id) : chatId;
-  const { data: chatData } = useMessageQuery(chatRoomId!, {
-    enabled: chatRoomId !== null,
-  });
+  const { data: chatData, refetch: refetchChatData } = useMessageQuery(
+    chatRoomId!,
+    {
+      enabled: chatRoomId !== null,
+    },
+  );
   const { data: chatInfo } = useChatInfoQuery(chatRoomId!, {
     enabled: chatRoomId !== null,
   });
   const failedChats = useFailedChatStore((state) => state.failedChats);
   const { addFailedChat, deleteFailedChat } = useFailedChatStore();
-  const { refetch } = useUnreadQuery(!!chatId);
+  const { refetch: refetchUnread } = useUnreadQuery(!!chatId);
 
   useEffect(() => {
-    if (!hasInitialized && chatData && chatRoomId) {
-      const failed = failedChats[chatRoomId] ?? [];
-      const messagesWithId = chatData.messages.map((chat) => ({
-        ...chat,
-        clientId: crypto.randomUUID(),
-      }));
-      setChats([...messagesWithId, ...failed]);
-      setHasInitialized(true);
-    }
-  }, [chatData, chatRoomId, failedChats, hasInitialized]);
-
-  useEffect(() => {
-    if (!hasInitialized) return;
-    if (chats.length === 0) return;
-
-    const behavior = hasMounted ? 'smooth' : 'auto';
-
-    const timer = setTimeout(() => {
-      bottomRef.current?.scrollIntoView({ behavior });
-      setHasMounted(true);
-    }, 50);
-
-    return () => clearTimeout(timer);
-  }, [chats.length, hasInitialized]);
+    if (!chatData || !chatRoomId) return;
+    const failed = failedChats[chatRoomId] ?? [];
+    setChats([...chatData.messages, ...failed]);
+  }, [chatData, chatRoomId, failedChats]);
 
   useEffect(() => {
     if (!chatRoomId) return;
-    refetch();
+    refetchUnread();
     const es = connectChat(
       chatRoomId,
       handleMessage,
@@ -88,14 +72,31 @@ const ChatRoom = () => {
     return () => {
       es.close();
     };
-  }, [chatRoomId]);
+  }, [chatRoomId, refetchUnread]);
+
+  useEffect(() => {
+    if (chats.length === 0) return;
+
+    const behavior = hasMounted ? 'smooth' : 'auto';
+    const timer = setTimeout(() => {
+      bottomRef.current?.scrollIntoView({ behavior });
+      setHasMounted(true);
+    }, 50);
+
+    return () => clearTimeout(timer);
+  }, [chats.length, hasMounted]);
 
   function handleRead() {
     setChats((prev) => prev.map((chat) => ({ ...chat, isRead: true })));
   }
 
   function handleMessage(data: ChatMessage) {
-    setChats((prev) => [...prev, { ...data, clientId: crypto.randomUUID() }]);
+    setChats((prev) => [
+      ...prev,
+      {
+        ...data,
+      },
+    ]);
   }
 
   function handleConnectError(error: Event) {
@@ -106,9 +107,11 @@ const ChatRoom = () => {
     setIsOpenMenu(false);
     setIsOpenDropdown(false);
   }
+
   function handleInputMessage(value: string) {
     setMessage(value);
   }
+
   function handleEnterEvent(e: React.KeyboardEvent) {
     if (e.key === 'Enter' && e.nativeEvent.isComposing === false)
       handleSendMessage();
@@ -117,14 +120,21 @@ const ChatRoom = () => {
   const { mutate: sendMessage } = useMessageMutate();
 
   function handleClickRefresh(idx: number) {
-    if (!chats[idx].clientId || !chatRoomId) return;
-    deleteFailedChat(chatRoomId, chats[idx].clientId);
-    handleSendMessage({ idx });
+    const chat = chats[idx];
+    if (!chatRoomId) return;
+    if ('clientId' in chat) {
+      deleteFailedChat(chatRoomId, chat.clientId);
+      handleSendMessage({ idx });
+    }
   }
+
   function handleClickDelete(idx: number) {
-    if (!chats[idx].clientId || !chatRoomId) return;
-    deleteFailedChat(chatRoomId, chats[idx].clientId);
-    setChats((prev) => prev.filter((_, i) => i !== idx));
+    const chat = chats[idx];
+    if (!chatRoomId) return;
+    if ('clientId' in chat) {
+      deleteFailedChat(chatRoomId, chat.clientId);
+      setChats((prev) => prev.filter((_, i) => i !== idx));
+    }
   }
 
   function handleSendMessage({
@@ -152,7 +162,7 @@ const ChatRoom = () => {
 
     const images = sendImages ? sendImages : [];
 
-    const nowChat = {
+    const nowChat: LocalChat = {
       type,
       content,
       images,
@@ -160,7 +170,10 @@ const ChatRoom = () => {
       isLoading: true,
       sentAt: String(new Date()),
       clientId:
-        typeof idx === 'number' ? chats[idx].clientId! : crypto.randomUUID(),
+        typeof idx === 'number' && 'clientId' in chats[idx]
+          ? chats[idx].clientId!
+          : crypto.randomUUID(),
+      isError: false,
     };
     if (!idx) {
       setChats((prev) => [...prev, nowChat]);
@@ -173,25 +186,30 @@ const ChatRoom = () => {
       },
       {
         onSuccess: (res) => {
+          const serverChat: ServerChat = {
+            id: res.id,
+            type: 'TEXT',
+            content: message,
+            images: [],
+            isMine: true,
+            isRead: res.isRead,
+            sentAt: res.sentAt,
+          };
           setChats((prev) =>
             prev.map((chat) =>
-              chat.clientId === nowChat.clientId
-                ? {
-                    ...chat,
-                    isLoading: false,
-                    isRead: res.isRead,
-                    sentAt: String(new Date()),
-                    isError: false,
-                  }
+              'clientId' in chat && chat.clientId === nowChat.clientId
+                ? serverChat
                 : chat,
             ),
           );
-          deleteFailedChat(chatRoomId, nowChat.clientId);
+          refetchChatData();
+          if (typeof idx === 'number')
+            deleteFailedChat(chatRoomId, nowChat.clientId);
         },
         onError: () => {
           setChats((prev) =>
             prev.map((chat) =>
-              chat.clientId === nowChat.clientId
+              'clientId' in chat && chat.clientId === nowChat.clientId
                 ? { ...chat, isError: true }
                 : chat,
             ),
@@ -254,7 +272,7 @@ const ChatRoom = () => {
             : false;
 
           return (
-            <React.Fragment key={chat.clientId}>
+            <React.Fragment key={'id' in chat ? chat.id : chat.clientId}>
               {chat.sentAt && isNewDate && (
                 <S.NoticeWrapper>
                   <S.DateText>{formatDate(chat.sentAt)}</S.DateText>
@@ -270,7 +288,7 @@ const ChatRoom = () => {
               ) : chat.isMine ? (
                 <S.SendChatWrapper>
                   <S.MessageInfo>
-                    {chat.isError ? (
+                    {'isError' in chat && chat.isError ? (
                       <S.ErrorBox>
                         <ChatRefreshIcon
                           stroke={theme.colors.BLACK}
@@ -283,11 +301,13 @@ const ChatRoom = () => {
                           onClick={() => handleClickDelete(idx)}
                         />
                       </S.ErrorBox>
-                    ) : chat.isLoading ? (
+                    ) : 'isLoading' in chat && chat.isLoading ? (
                       <SendReverseIcon fill={theme.colors.GRAY_500} />
                     ) : (
                       <>
-                        {!chat.isRead && <S.UnreadText>1</S.UnreadText>}
+                        {'isRead' in chat && !chat.isRead && (
+                          <S.UnreadText>1</S.UnreadText>
+                        )}
                         {chat.sentAt && (
                           <S.TimeText>{formatTime(chat.sentAt)}</S.TimeText>
                         )}

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -8,6 +8,7 @@ import {
   useChatInfoQuery,
   useMessageMutate,
   useMessageQuery,
+  useUnreadQuery,
 } from '@/entities/chat';
 import {
   AddIcon,
@@ -47,6 +48,7 @@ const ChatRoom = () => {
   });
   const failedChats = useFailedChatStore((state) => state.failedChats);
   const { addFailedChat, deleteFailedChat } = useFailedChatStore();
+  const { refetch } = useUnreadQuery(!!chatId);
 
   useEffect(() => {
     if (!hasInitialized && chatData && chatRoomId) {
@@ -76,6 +78,7 @@ const ChatRoom = () => {
 
   useEffect(() => {
     if (!chatRoomId) return;
+    refetch();
     const es = connectChat(
       chatRoomId,
       handleMessage,

--- a/src/shared/model/connectNoti.ts
+++ b/src/shared/model/connectNoti.ts
@@ -31,7 +31,7 @@ export const connectNoti = (
 
   es.onerror = (e) => {
     onError(e);
-    es.close();
   };
+
   return es;
 };

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -59,9 +59,12 @@ const FloatingButton = () => {
 
   useEffect(() => {
     if (!isLogin) return;
-    connectNoti(onNoti, () => {
+    const es = connectNoti(onNoti, () => {
       console.log('error');
     });
+    return () => {
+      es.close();
+    };
   }, [isLogin, onNoti]);
 
   const hideButton =

--- a/src/shared/ui/FloatingButton.tsx
+++ b/src/shared/ui/FloatingButton.tsx
@@ -29,28 +29,33 @@ const FloatingButton = () => {
   const { toggleIsOpen, resetChat, resetAll } = useFABStore();
   const handleOpenChat = useHandleOpenChat();
   const isLogin = useMyStore((s) => s.isLogin);
-  const { data: unRead } = useUnreadQuery(isLogin);
+  const { data: unRead, refetch: unReadRefetch } = useUnreadQuery(isLogin);
   const unReadCount = unRead ? unRead.unreadCount : 0;
 
   const [visibleNoti, setVisibleNoti] = useState<Notification | null>(null);
   const [dismissing, setDismissing] = useState<boolean>(false);
   const timers = useRef<{ fade?: number; clear?: number }>({});
 
-  const onNoti = useCallback((newNoti: Notification) => {
-    clearTimeout(timers.current.fade);
-    clearTimeout(timers.current.clear);
+  const onNoti = useCallback(
+    (newNoti: Notification) => {
+      clearTimeout(timers.current.fade);
+      clearTimeout(timers.current.clear);
 
-    setVisibleNoti(newNoti);
-    setDismissing(false);
+      setVisibleNoti(newNoti);
+      setDismissing(false);
 
-    timers.current.fade = window.setTimeout(() => {
-      setDismissing(true);
-    }, 2500);
+      timers.current.fade = window.setTimeout(() => {
+        setDismissing(true);
+      }, 2500);
 
-    timers.current.clear = window.setTimeout(() => {
-      setVisibleNoti(null);
-    }, 3000);
-  }, []);
+      timers.current.clear = window.setTimeout(() => {
+        setVisibleNoti(null);
+      }, 3000);
+
+      unReadRefetch();
+    },
+    [unReadRefetch],
+  );
 
   useEffect(() => {
     if (!isLogin) return;


### PR DESCRIPTION
### #️⃣연관된 이슈
> #103 

### 📜 작업 내용
- [x] 알림 수신 및 채팅방 입장 시 unreadCount 갱신
- [x] SSE onError 시 자동 재연결 동작하도록 로직 수정
- [x] 채팅 서버/로컬 타입 분리 및 초기 메시지 로딩 로직 수정

### 🖼️ 스크린샷 (선택)

### 📄 참고 링크 (선택)

### ⚠️ 종료할 이슈
this closes #103 
