### PR TITLE
fix: 마이페이지 활동 지역 인증 상태 구분

### DIFF
--- a/src/features/user/ui/EditArea.tsx
+++ b/src/features/user/ui/EditArea.tsx
@@ -20,9 +20,11 @@ const EditArea = (area: EditAreaProps) => {
   return (
     <S.EditAreaContainer>
       <div style={{ marginBottom: 10 }}>
-        <span style={{ fontWeight: 600 }}>활동 지역 변경</span>
-        <S.InfoText>
-          *{emdName} 인증됨 ({formatDate(area.authenticatedAt)})
+        <span style={{ fontWeight: 600 }}>활동 지역</span>
+        <S.InfoText $isAuthentication={area.isAuthentication}>
+          {area.isAuthentication
+            ? `*${emdName} 인증됨 (${formatDate(area.authenticatedAt)})`
+            : `*위치 인증이 필요합니다`}
         </S.InfoText>
       </div>
       <SelectAreaSection purpose='CHANGE_AREA' onSuccess={handleEditArea} />

--- a/src/features/user/ui/EditArea.tsx
+++ b/src/features/user/ui/EditArea.tsx
@@ -1,4 +1,3 @@
-import { toast } from 'react-toastify';
 import emd_areas from '@/shared/constants/emd_areas.json';
 import { formatDate, queryClient } from '@/shared/lib';
 import { SelectAreaSection } from '@/shared/ui';

--- a/src/features/user/ui/EditArea.tsx
+++ b/src/features/user/ui/EditArea.tsx
@@ -14,7 +14,6 @@ const EditArea = (area: EditAreaProps) => {
   const emdName = emd_areas.find((area) => area.id === defaultEmdId)?.name;
 
   function handleEditArea() {
-    toast.success('활동 지역 변경 완료!');
     queryClient.invalidateQueries({ queryKey: ['my'] });
   }
   return (

--- a/src/features/user/ui/EditProfile.styles.ts
+++ b/src/features/user/ui/EditProfile.styles.ts
@@ -45,9 +45,10 @@ export const AreaInfoBar = styled.div`
   align-items: center;
 `;
 
-export const InfoText = styled.span`
+export const InfoText = styled.span<{ $isAuthentication: boolean }>`
   margin-left: 10px;
-  color: ${({ theme }) => theme.colors.GRAY_600};
+  color: ${({ theme, $isAuthentication }) =>
+    $isAuthentication ? theme.colors.GRAY_600 : theme.colors.BADGE};
   font-size: 14px;
 `;
 


### PR DESCRIPTION
this closes | fixes #113

### 작업 내용
작업 내용을 적어주세요. 
- [x] 인증 상태에 따른 문구 구분
- [x] "활동 지역 변경 완료" 토스트 메시지 제거
    - 한 버튼으로 활동 지역 변경, 위치 인증 갱신 두 가지 작업을 하기 때문에 이 문구가 적절하지 않다고 생각했습니다. 
    - 인증 완료 시 인증 완료 토스트 메시지가 뜨기 때문에 이 메시지는 제거해도 된다고 판단

---

### 참고
> 관련 이미지 첨부
<img width="300" alt="image" src="https://github.com/user-attachments/assets/854bc397-a0a7-47a2-9886-ac5dacd6de80" />
