### PR TITLE
feat: 거래 요청 기능 및 UI 구현

### DIFF
--- a/src/entities/trade/api.ts
+++ b/src/entities/trade/api.ts
@@ -21,3 +21,14 @@ export const patchTrade = async ({
   });
   return data;
 };
+
+export interface PostTradeProps {
+  postId: number;
+  itemIds: number[];
+  isFar: boolean;
+}
+
+export const postTrade = async (prop: PostTradeProps) => {
+  const { data } = await axiosInstance.post('trades', prop);
+  return data;
+};

--- a/src/entities/trade/queries.ts
+++ b/src/entities/trade/queries.ts
@@ -1,6 +1,12 @@
 import { toast } from 'react-toastify';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { getTrades, patchTrade, TradeProps } from '.';
+import {
+  getTrades,
+  patchTrade,
+  postTrade,
+  PostTradeProps,
+  TradeProps,
+} from '.';
 import { queryClient } from '@/shared/lib';
 
 export const useTradeQuery = (postId: number) => {
@@ -18,7 +24,16 @@ export const useTradeMutation = (postId: number) => {
         queryKey: ['listingDetail', postId],
       });
       await queryClient.invalidateQueries({ queryKey: ['trade', postId] });
-      toast.success('거래 상태가 변경되었습니다.');
+      toast.success('거래 상태가 변경되었습니다');
+    },
+  });
+};
+
+export const usePostTradeMutation = () => {
+  return useMutation<void, Error, PostTradeProps>({
+    mutationFn: (data) => postTrade(data),
+    onSuccess: () => {
+      toast.success('거래 요청이 완료되었습니다');
     },
   });
 };

--- a/src/entities/user/api.ts
+++ b/src/entities/user/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/shared/config/axios';
-import { UserProfileProps } from '.';
+import { Bookcase, BookcaseRequest, UserProfileProps } from '.';
 
 export const getMyProfile = async (): Promise<UserProfileProps> => {
   const { data } = await axiosInstance.get('/members/me');
@@ -30,4 +30,28 @@ export const patchTempPassword = async (email: string) => {
 export const getUserProfile = async (id: string): Promise<UserProfileProps> => {
   const { data } = await axiosInstance.get(`/members/${id}`);
   return data;
+};
+
+export const postUserBookcase = async (book: BookcaseRequest) => {
+  const { data } = await axiosInstance.post('members/books', book);
+  return data;
+};
+
+export interface GetBookcaseProps {
+  memberId: string;
+  key?: 'AVAILABLE' | 'UNAVAILABLE';
+  require?: number[];
+}
+
+export const getBookcase = async (
+  prop: GetBookcaseProps,
+): Promise<Bookcase[]> => {
+  const { memberId, key, require } = prop;
+  const { data } = await axiosInstance.get(`/members/${memberId}/books`, {
+    params: {
+      ...(key && { key }),
+      ...(require && { require }),
+    },
+  });
+  return data.bookcase;
 };

--- a/src/entities/user/queries.ts
+++ b/src/entities/user/queries.ts
@@ -1,12 +1,16 @@
 import { toast } from 'react-toastify';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
+  BookcaseRequest,
+  getBookcase,
+  GetBookcaseProps,
   getMyProfile,
   getUserProfile,
   patchNickname,
   patchPassword,
   patchPasswordProps,
   patchTempPassword,
+  postUserBookcase,
 } from '.';
 import { queryClient } from '@/shared/lib';
 
@@ -53,5 +57,32 @@ export const useUserQuery = (id: string) => {
   return useQuery({
     queryKey: ['user', id],
     queryFn: ({ queryKey }) => getUserProfile(queryKey[1]),
+  });
+};
+
+export const useBookcaseMutation = () => {
+  return useMutation<void, Error, BookcaseRequest>({
+    mutationFn: (data) => postUserBookcase(data),
+    onSuccess: () => {
+      const myData = queryClient.getQueryData<{ memberId: string }>(['my']);
+      const myId = myData?.memberId;
+      toast.success('책 등록 완료');
+      if (myId) {
+        queryClient.invalidateQueries({ queryKey: ['bookcase', myId] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['bookcase'] });
+      }
+    },
+  });
+};
+
+export const useBookcaseQuery = (
+  prop: GetBookcaseProps,
+  options?: { enabled?: boolean },
+) => {
+  return useQuery({
+    queryKey: ['bookcase', prop.memberId],
+    queryFn: () => getBookcase(prop),
+    enabled: options?.enabled ?? !!prop.memberId,
   });
 };

--- a/src/entities/user/type.ts
+++ b/src/entities/user/type.ts
@@ -1,4 +1,4 @@
-import { BookStatus } from '../listing';
+import { BookState, BookStatus } from '../listing';
 
 export interface UserProfileProps {
   isSocial: boolean;
@@ -22,7 +22,12 @@ export interface Book {
   author: string;
   cover: string;
 }
+
 export interface Bookcase extends Book {
   status: BookStatus;
   available: boolean;
+}
+
+export interface BookcaseRequest extends BookState {
+  status: BookStatus;
 }

--- a/src/features/listing/ui/detail/ListingDetail.tsx
+++ b/src/features/listing/ui/detail/ListingDetail.tsx
@@ -6,11 +6,12 @@ import { useTheme } from 'styled-components';
 
 import { useLikeMutation, useListingDetailQuery } from '@/entities/listing';
 import { bookStatusMap, convertDiffToString } from '@/shared/lib';
-import { calcDistance, getCategoryNameById } from '../../lib';
+import { LoadingIndicator, ModalLayout } from '@/shared/ui';
 import BookItem from '@/features/user/ui/profile/BookItem';
+import { TradeRequest } from '@/features/trade/ui';
 import { useChatMutation } from '@/entities/chat';
 import { LikeIcon } from '@/shared/assets/icons';
-import { LoadingIndicator } from '@/shared/ui';
+import { getCategoryNameById } from '../../lib';
 import { useMyQuery } from '@/entities/user';
 import { colors } from '@/shared/constants';
 import * as S from './ListingDetail.styles';
@@ -34,6 +35,7 @@ const ListingDetail = ({ id }: { id: number }) => {
   const [likeCount, setLikeCount] = useState<number | undefined>(undefined);
   const { mutate: controlLike } = useLikeMutation();
   const { mutate: makeChat } = useChatMutation();
+  const [openTradeRequest, setOpenTradeRequest] = useState(false);
 
   function handleLike() {
     if (data?.isOwner) {
@@ -43,17 +45,22 @@ const ListingDetail = ({ id }: { id: number }) => {
     setLiked((prev) => !prev);
   }
 
-  function handleClickChat() {
-    if (!data || !mydata) return;
-    const isFar = calcDistance(mydata.area.emdId, data.writer.emdId);
-    makeChat(
-      { postId: data.postId, isFar },
-      {
-        onSuccess: (res) => {
-          console.log(res);
-        },
-      },
-    );
+  function handleClickExchange() {
+    if (!data || !mydata) {
+      toast.info('로그인 후 이용해 주세요');
+      return;
+    }
+
+    setOpenTradeRequest(true);
+    // const isFar = calcDistance(mydata.area.emdId, data.writer.emdId);
+    // makeChat(
+    //   { postId: data.postId, isFar },
+    //   {
+    //     onSuccess: (res) => {
+    //       console.log(res);
+    //     },
+    //   },
+    // );
   }
 
   useEffect(() => {
@@ -141,8 +148,8 @@ const ListingDetail = ({ id }: { id: number }) => {
                   />
                   찜하기
                 </S.Button>
-                <S.Button variant='primary' onClick={handleClickChat}>
-                  제안하기
+                <S.Button variant='primary' onClick={handleClickExchange}>
+                  교환 신청
                 </S.Button>
               </S.ButtonRow>
               {data.wishOnly && (
@@ -177,6 +184,14 @@ const ListingDetail = ({ id }: { id: number }) => {
         <S.LoadingContainer>
           <LoadingIndicator text='불러오는중' />
         </S.LoadingContainer>
+      )}
+      {openTradeRequest && (
+        <ModalLayout
+          isOpen={openTradeRequest}
+          title='교환할 책을 선택해 주세요'
+          onClose={() => setOpenTradeRequest(false)}>
+          <TradeRequest />
+        </ModalLayout>
       )}
     </>
   );

--- a/src/features/listing/ui/detail/ListingDetail.tsx
+++ b/src/features/listing/ui/detail/ListingDetail.tsx
@@ -6,12 +6,12 @@ import { useTheme } from 'styled-components';
 
 import { useLikeMutation, useListingDetailQuery } from '@/entities/listing';
 import { bookStatusMap, convertDiffToString } from '@/shared/lib';
+import { calcDistance, getCategoryNameById } from '../../lib';
 import { LoadingIndicator, ModalLayout } from '@/shared/ui';
 import BookItem from '@/features/user/ui/profile/BookItem';
 import { TradeRequest } from '@/features/trade/ui';
 import { useChatMutation } from '@/entities/chat';
 import { LikeIcon } from '@/shared/assets/icons';
-import { getCategoryNameById } from '../../lib';
 import { useMyQuery } from '@/entities/user';
 import { colors } from '@/shared/constants';
 import * as S from './ListingDetail.styles';
@@ -50,17 +50,7 @@ const ListingDetail = ({ id }: { id: number }) => {
       toast.info('로그인 후 이용해 주세요');
       return;
     }
-
     setOpenTradeRequest(true);
-    // const isFar = calcDistance(mydata.area.emdId, data.writer.emdId);
-    // makeChat(
-    //   { postId: data.postId, isFar },
-    //   {
-    //     onSuccess: (res) => {
-    //       console.log(res);
-    //     },
-    //   },
-    // );
   }
 
   useEffect(() => {
@@ -185,12 +175,16 @@ const ListingDetail = ({ id }: { id: number }) => {
           <LoadingIndicator text='불러오는중' />
         </S.LoadingContainer>
       )}
-      {openTradeRequest && (
+      {openTradeRequest && mydata && data && (
         <ModalLayout
           isOpen={openTradeRequest}
           title='교환할 책을 선택해 주세요'
           onClose={() => setOpenTradeRequest(false)}>
-          <TradeRequest />
+          <TradeRequest
+            isFar={calcDistance(mydata.area.emdId, data.writer.emdId)}
+            postId={id}
+            onClose={() => setOpenTradeRequest(false)}
+          />
         </ModalLayout>
       )}
     </>

--- a/src/features/listing/ui/write/SearchSection.tsx
+++ b/src/features/listing/ui/write/SearchSection.tsx
@@ -32,6 +32,7 @@ const SearchSection = ({ value, onChange }: SearchSectionProps) => {
     setBook(book);
     setIsOpen(false);
   }
+
   return (
     <Container>
       <S.HeaderWrapper>

--- a/src/features/search/ui/SearchModalContent.tsx
+++ b/src/features/search/ui/SearchModalContent.tsx
@@ -11,7 +11,7 @@ import { searchBook } from '@/entities/aladin';
 
 interface SearchModalContentProps {
   value?: string;
-  onClose: () => void;
+  onClose?: () => void;
   onSelectBook: (book: BookState) => void;
 }
 

--- a/src/features/trade/ui/SelectBook.tsx
+++ b/src/features/trade/ui/SelectBook.tsx
@@ -5,28 +5,13 @@ import { bookStatusMap } from '@/shared/lib';
 import { Bookcase } from '@/entities/user';
 import { Button } from '@/shared/ui';
 
-const bookcase: Bookcase[] = [
-  {
-    id: 13,
-    status: 'BEST',
-    title: '파쇄',
-    author: '구병모 지음',
-    cover:
-      'https://image.aladin.co.kr/product/31273/29/cover500/k592832565_1.jpg',
-    available: true,
-  },
-  {
-    id: 15,
-    status: 'HIGH',
-    title: '안녕! 보노보노 컬러링 엽서북 - 애니메이션 원화로 그리는',
-    author: '미르북컴퍼니 편집부 지음',
-    cover:
-      'https://image.aladin.co.kr/product/34116/30/cover500/k712931484_1.jpg',
-    available: true,
-  },
-];
-
-const SelectBook = () => {
+const SelectBook = ({
+  books,
+  onTradeRequest,
+}: {
+  books: Bookcase[];
+  onTradeRequest: (selected: Bookcase[]) => void;
+}) => {
   const [selected, setSelected] = useState<Bookcase[]>([]);
 
   function handleClickItem(book: Bookcase) {
@@ -40,13 +25,10 @@ const SelectBook = () => {
     });
   }
 
-  function handleClickTradeRequest() {
-    console.log('request');
-  }
   return (
     <Container>
       <BookList>
-        {bookcase.map((book) => (
+        {books.map((book) => (
           <ItemWrapper
             key={book.id}
             $isSelected={!!selected.find((b) => b.id === book.id)}
@@ -76,7 +58,7 @@ const SelectBook = () => {
         <div style={{ width: '25%' }}>
           <Button
             text='교환 신청'
-            onClick={handleClickTradeRequest}
+            onClick={() => onTradeRequest(selected)}
             size='sm'
           />
         </div>

--- a/src/features/trade/ui/SelectBook.tsx
+++ b/src/features/trade/ui/SelectBook.tsx
@@ -1,0 +1,167 @@
+import Image from 'next/image';
+import { useState } from 'react';
+import styled from 'styled-components';
+import { bookStatusMap } from '@/shared/lib';
+import { Bookcase } from '@/entities/user';
+import { Button } from '@/shared/ui';
+
+const bookcase: Bookcase[] = [
+  {
+    id: 13,
+    status: 'BEST',
+    title: '파쇄',
+    author: '구병모 지음',
+    cover:
+      'https://image.aladin.co.kr/product/31273/29/cover500/k592832565_1.jpg',
+    available: true,
+  },
+  {
+    id: 15,
+    status: 'HIGH',
+    title: '안녕! 보노보노 컬러링 엽서북 - 애니메이션 원화로 그리는',
+    author: '미르북컴퍼니 편집부 지음',
+    cover:
+      'https://image.aladin.co.kr/product/34116/30/cover500/k712931484_1.jpg',
+    available: true,
+  },
+];
+
+const SelectBook = () => {
+  const [selected, setSelected] = useState<Bookcase[]>([]);
+
+  function handleClickItem(book: Bookcase) {
+    setSelected((prev) => {
+      const exists = prev.find((b) => b.id === book.id);
+      if (exists) {
+        return prev.filter((b) => b.id !== book.id);
+      } else {
+        return [...prev, book];
+      }
+    });
+  }
+
+  function handleClickTradeRequest() {
+    console.log('request');
+  }
+  return (
+    <Container>
+      <BookList>
+        {bookcase.map((book) => (
+          <ItemWrapper
+            key={book.id}
+            $isSelected={!!selected.find((b) => b.id === book.id)}
+            onClick={() => handleClickItem(book)}>
+            <ImageWrapper>
+              <Image
+                src={book.cover}
+                alt={book.title}
+                fill
+                style={{ objectFit: 'cover' }}
+              />
+            </ImageWrapper>
+            <BookInfo>
+              <TitleText>{book.title}</TitleText>
+              <InfoText>{`${book.author} | ${bookStatusMap[book.status]}`}</InfoText>
+            </BookInfo>
+          </ItemWrapper>
+        ))}
+      </BookList>
+      <SelectedBook>
+        {selected.map((book) => (
+          <SelectedBookTitle key={book.id}>{book.title}</SelectedBookTitle>
+        ))}
+      </SelectedBook>
+      <Footer>
+        <InfoText>⚠️ 이전 신청과 같은 조합으로는 신청이 불가능합니다</InfoText>
+        <div style={{ width: '25%' }}>
+          <Button
+            text='교환 신청'
+            onClick={handleClickTradeRequest}
+            size='sm'
+          />
+        </div>
+      </Footer>
+    </Container>
+  );
+};
+
+export default SelectBook;
+
+const Container = styled.div`
+  padding: 10px;
+`;
+
+const BookList = styled.div`
+  max-height: 280px;
+  overflow-y: scroll;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const ItemWrapper = styled.div<{ $isSelected: boolean }>`
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  ${({ $isSelected, theme }) =>
+    $isSelected &&
+    `
+  background-color: ${theme.colors.PRIMARY_100};
+  border: 1.5px solid ${theme.colors.PRIMARY};
+  `}
+  cursor: pointer;
+  border-radius: 12px;
+`;
+
+const ImageWrapper = styled.div`
+  position: relative;
+  width: 10%;
+  aspect-ratio: 1 / 1;
+  flex: none;
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+const BookInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const TitleText = styled.div`
+  font-size: 14px;
+  font-weight: 500;
+`;
+
+const InfoText = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.GRAY_500};
+`;
+
+const SelectedBook = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  gap: 6px;
+`;
+
+const SelectedBookTitle = styled.div`
+  display: inline-flex;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 14px;
+  border: 1px solid ${({ theme }) => theme.colors.GRAY_400};
+`;
+
+const Footer = styled.div`
+  margin-top: 10px;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;

--- a/src/features/trade/ui/Tab.tsx
+++ b/src/features/trade/ui/Tab.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+
+interface TabProps {
+  tabs: string[];
+  selected: number;
+  onChange: (v: number) => void;
+}
+
+const Tab = ({ tabs, selected = 0, onChange }: TabProps) => {
+  return (
+    <ListWrapper>
+      {tabs.map((label, i) => (
+        <ListItem
+          $isSelect={selected === i}
+          key={i}
+          className={i === selected ? 'active' : ''}
+          onClick={() => onChange(i)}>
+          {label}
+        </ListItem>
+      ))}
+    </ListWrapper>
+  );
+};
+
+export default Tab;
+
+const ListWrapper = styled.ul`
+  width: 100%;
+  display: flex;
+  height: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-bottom: 3px solid ${({ theme }) => theme.colors.GRAY_300};
+`;
+
+interface ListItemProps {
+  $isSelect: boolean;
+}
+
+const ListItem = styled.li<ListItemProps>`
+  cursor: pointer;
+  font-size: 16px;
+  padding: 8px 0;
+  text-align: center;
+  white-space: nowrap;
+  flex-shrink: 0;
+  flex: 1;
+  font-weight: ${({ $isSelect }) => ($isSelect ? 500 : 400)};
+  color: ${({ $isSelect, theme }) =>
+    $isSelect ? theme.colors.BLACK : theme.colors.GRAY_500};
+  border-bottom: 3px solid
+    ${({ $isSelect, theme }) => ($isSelect ? theme.colors.BLACK : 'none')};
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
+    font-size: 14px;
+  }
+`;

--- a/src/features/trade/ui/TradeRequest.tsx
+++ b/src/features/trade/ui/TradeRequest.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import Tab from './Tab';
+import { SearchModalContent } from '@/features/search/ui';
+import { BookState, BookStatus } from '@/entities/listing';
+import { ModalLayout } from '@/shared/ui';
+import SelectBookStatus from '@/features/user/ui/profile/SelectBookStatus';
+import SelectBook from './SelectBook';
+
+const TradeRequest = () => {
+  const tabs = ['책 선택', '책 등록'];
+  const [selectedTab, setSelectedTab] = useState(0);
+  const [openStatusModal, setOpenStatusModal] = useState(false);
+
+  function handleChangeTab(v: number) {
+    setSelectedTab(v);
+  }
+
+  function handleSelectAddBook(book: BookState) {
+    console.log(book);
+    setOpenStatusModal(true);
+  }
+
+  function handleSelectBookStatus(bookStatus: BookStatus) {
+    console.log(bookStatus);
+    setOpenStatusModal(false);
+    setSelectedTab(0);
+  }
+
+  return (
+    <Container>
+      <Tab tabs={tabs} selected={selectedTab} onChange={handleChangeTab} />
+      {selectedTab === 0 ? (
+        <SelectBook />
+      ) : (
+        <SearchModalContent onSelectBook={handleSelectAddBook} />
+      )}
+      {openStatusModal && (
+        <ModalLayout
+          isOpen={openStatusModal}
+          onClose={() => setOpenStatusModal(false)}
+          title='책 상태 입력'>
+          <SelectBookStatus onSelect={handleSelectBookStatus} />
+        </ModalLayout>
+      )}
+    </Container>
+  );
+};
+
+export default TradeRequest;
+
+const Container = styled.div`
+  width: 100%;
+`;

--- a/src/features/trade/ui/TradeRequest.tsx
+++ b/src/features/trade/ui/TradeRequest.tsx
@@ -1,40 +1,95 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import Tab from './Tab';
-import { SearchModalContent } from '@/features/search/ui';
-import { BookState, BookStatus } from '@/entities/listing';
-import { ModalLayout } from '@/shared/ui';
 import SelectBookStatus from '@/features/user/ui/profile/SelectBookStatus';
+import { LoadingIndicator, ModalLayout } from '@/shared/ui';
+import { BookState, BookStatus } from '@/entities/listing';
+import { SearchModalContent } from '@/features/search/ui';
+import { usePostTradeMutation } from '@/entities/trade';
 import SelectBook from './SelectBook';
+import {
+  Bookcase,
+  useBookcaseMutation,
+  useBookcaseQuery,
+  useMyQuery,
+} from '@/entities/user';
+import Tab from './Tab';
 
-const TradeRequest = () => {
+const TradeRequest = ({
+  postId,
+  isFar,
+  onClose,
+}: {
+  postId: number;
+  isFar: boolean;
+  onClose: () => void;
+}) => {
   const tabs = ['책 선택', '책 등록'];
   const [selectedTab, setSelectedTab] = useState(0);
   const [openStatusModal, setOpenStatusModal] = useState(false);
+  const [selectedBook, setSelectedBook] = useState<BookState | null>(null);
+  const { data: mydata } = useMyQuery();
+  const { data: bookcaseData, isLoading } = useBookcaseQuery(
+    { memberId: mydata?.memberId ?? '', key: 'AVAILABLE' },
+    { enabled: !!mydata?.memberId },
+  );
+  const { mutate: enterBookcaseBook } = useBookcaseMutation();
+  const { mutate: requestTrade } = usePostTradeMutation();
+
+  if (isLoading || !bookcaseData) {
+    return <LoadingIndicator text='로딩중' />;
+  }
 
   function handleChangeTab(v: number) {
     setSelectedTab(v);
   }
 
   function handleSelectAddBook(book: BookState) {
-    console.log(book);
+    setSelectedBook(book);
     setOpenStatusModal(true);
   }
 
   function handleSelectBookStatus(bookStatus: BookStatus) {
-    console.log(bookStatus);
+    if (!selectedBook) return;
+
+    const bookWithStatus = {
+      ...selectedBook,
+      status: bookStatus,
+    };
+    enterBookcaseBook(bookWithStatus);
     setOpenStatusModal(false);
     setSelectedTab(0);
+  }
+
+  function handleTradeRequest(selected: Bookcase[]) {
+    const itemIds = selected.map((book) => book.id);
+    requestTrade(
+      { postId, itemIds, isFar },
+      {
+        onSuccess: () => {
+          onClose();
+        },
+      },
+    );
   }
 
   return (
     <Container>
       <Tab tabs={tabs} selected={selectedTab} onChange={handleChangeTab} />
       {selectedTab === 0 ? (
-        <SelectBook />
+        bookcaseData.length === 0 ? (
+          <EmptyText>
+            등록된 책이 없습니다. 책 등록 탭에서 추가하세요.
+          </EmptyText>
+        ) : (
+          <SelectBook
+            books={bookcaseData}
+            onTradeRequest={handleTradeRequest}
+          />
+        )
       ) : (
         <SearchModalContent onSelectBook={handleSelectAddBook} />
       )}
+
       {openStatusModal && (
         <ModalLayout
           isOpen={openStatusModal}
@@ -51,4 +106,9 @@ export default TradeRequest;
 
 const Container = styled.div`
   width: 100%;
+`;
+
+const EmptyText = styled.div`
+  text-align: center;
+  margin: 10px;
 `;

--- a/src/features/trade/ui/TradeRequest.tsx
+++ b/src/features/trade/ui/TradeRequest.tsx
@@ -78,7 +78,7 @@ const TradeRequest = ({
       {selectedTab === 0 ? (
         bookcaseData.length === 0 ? (
           <EmptyText>
-            등록된 책이 없습니다. 책 등록 탭에서 추가하세요.
+            {`거래에 이용 가능한 책이 없습니다 \n 책 등록 탭에서 추가해 주세요`}
           </EmptyText>
         ) : (
           <SelectBook
@@ -111,4 +111,7 @@ const Container = styled.div`
 const EmptyText = styled.div`
   text-align: center;
   margin: 10px;
+  color: ${({ theme }) => theme.colors.GRAY_600};
+  white-space: pre-wrap;
+  font-size: 14px;
 `;

--- a/src/features/trade/ui/index.ts
+++ b/src/features/trade/ui/index.ts
@@ -1,4 +1,5 @@
 import CancelTradeForm from './CancelTradeForm';
 import SelectBuyerForm from './SelectBuyerForm';
+import TradeRequest from './TradeRequest';
 
-export { SelectBuyerForm, CancelTradeForm };
+export { SelectBuyerForm, CancelTradeForm, TradeRequest };

--- a/src/features/user/ui/SubTab.tsx
+++ b/src/features/user/ui/SubTab.tsx
@@ -1,10 +1,5 @@
 import styled from 'styled-components';
 
-export type SubTab = {
-  value: number;
-  label: string;
-};
-
 interface SubTabsProps {
   tabs: string[];
   selected: number;

--- a/src/features/user/ui/index.ts
+++ b/src/features/user/ui/index.ts
@@ -1,4 +1,5 @@
-import My from './My';
 import PasswordRequestLayout from './PasswordRequestLayout';
 import UserProfile from './UserProfile';
+import My from './My';
+
 export { My, PasswordRequestLayout, UserProfile };

--- a/src/features/user/ui/profile/BookShelfSection.tsx
+++ b/src/features/user/ui/profile/BookShelfSection.tsx
@@ -1,14 +1,12 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { Button, CheckCircle, ModalLayout } from '@/shared/ui';
-import { bookStatusList } from '@/features/listing/ui/main/filter/FilterContent';
+import { ModalLayout } from '@/shared/ui';
 import { BookState, BookStatus } from '@/entities/listing';
 import { SearchModalContent } from '@/features/search/ui';
-import { HELP_MESSAGES } from '@/shared/constants';
 import { Book, Bookcase } from '@/entities/user';
-import { bookStatusMap } from '@/shared/lib';
 import AddBookItem from './AddBookItem';
 import BookItem from './BookItem';
+import SelectBookStatus from './SelectBookStatus';
 
 type Modal = 'STATUS' | 'ADD';
 const BookShelfSection = ({
@@ -20,7 +18,6 @@ const BookShelfSection = ({
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [activeModal, setActiveModal] = useState<Modal | undefined>();
-  const [bookStatus, setBookStatus] = useState<BookStatus | undefined>();
 
   function handleEditMode() {
     setEditMode((prev) => !prev);
@@ -32,7 +29,6 @@ const BookShelfSection = ({
   }
 
   function handleReset() {
-    setBookStatus(undefined);
     setActiveModal(undefined);
   }
 
@@ -44,7 +40,7 @@ const BookShelfSection = ({
     } else handleReset();
   }
 
-  function handleSelectBookStatus() {
+  function handleSelectBookStatus(bookStatus: BookStatus) {
     console.log(bookStatus);
     setActiveModal(undefined);
     handleReset();
@@ -85,32 +81,7 @@ const BookShelfSection = ({
             isOpen={activeModal === 'STATUS'}
             onClose={handleReset}
             title='책 상태 입력'>
-            <StatusSection>
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  gap: 8,
-                }}>
-                {bookStatusList.map((status) => (
-                  <CheckCircle
-                    key={status}
-                    id={bookStatusMap[status]}
-                    checked={bookStatus === status}
-                    onChange={() => setBookStatus(status)}
-                    label={
-                      <OptionText>{bookStatusMap[status]}</OptionText>
-                    }></CheckCircle>
-                ))}
-              </div>
-              <Button
-                text='완료'
-                onClick={handleSelectBookStatus}
-                variant={bookStatus ? 'primary' : 'disabled'}
-              />
-              <HelpText>{HELP_MESSAGES.state}</HelpText>
-            </StatusSection>
+            <SelectBookStatus onSelect={handleSelectBookStatus} />
           </ModalLayout>
         ))}
     </Container>
@@ -161,17 +132,4 @@ const EditButton = styled.div<{ $editMode: boolean }>`
   @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
     font-size: 12px;
   }
-`;
-
-const StatusSection = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-`;
-
-const OptionText = styled.div`
-  margin: 0 5px;
 `;

--- a/src/features/user/ui/profile/SelectBookStatus.tsx
+++ b/src/features/user/ui/profile/SelectBookStatus.tsx
@@ -1,0 +1,71 @@
+import { BookStatus } from '@/entities/listing';
+import { bookStatusList } from '@/features/listing/ui/main/filter/FilterContent';
+import { HELP_MESSAGES } from '@/shared/constants';
+import { bookStatusMap } from '@/shared/lib';
+import { Button, CheckCircle } from '@/shared/ui';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const SelectBookStatus = ({
+  onSelect,
+}: {
+  onSelect: (bookStatus: BookStatus) => void;
+}) => {
+  const [bookStatus, setBookStatus] = useState<BookStatus | undefined>();
+
+  function handleSelectStatus() {
+    if (!bookStatus) return;
+    onSelect(bookStatus);
+    setBookStatus(undefined);
+  }
+
+  return (
+    <StatusSection>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          gap: 8,
+        }}>
+        {bookStatusList.map((status) => (
+          <CheckCircle
+            key={status}
+            id={bookStatusMap[status]}
+            checked={bookStatus === status}
+            onChange={() => setBookStatus(status)}
+            label={
+              <OptionText>{bookStatusMap[status]}</OptionText>
+            }></CheckCircle>
+        ))}
+      </div>
+      <Button
+        text='완료'
+        onClick={handleSelectStatus}
+        variant={bookStatus ? 'primary' : 'disabled'}
+      />
+      <HelpText>{HELP_MESSAGES.state}</HelpText>
+    </StatusSection>
+  );
+};
+
+export default SelectBookStatus;
+
+const HelpText = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.GRAY_700};
+  white-space: pre-line;
+`;
+
+const StatusSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+`;
+
+const OptionText = styled.div`
+  margin: 0 5px;
+`;


### PR DESCRIPTION
this closes | fixes #128 

### 작업 내용
- [x] 거래 요청 모달 UI 구현
- [x] 거래 요청 API 연동
- [x] 책장 조회 및 책장 도서 등록 API 연동(거래 요청 UI에 한함)

### 참고 
<img width="1254" height="716" alt="image" src="https://github.com/user-attachments/assets/d99349f8-3559-4973-971f-dde50beef72a" />
