### PR TITLE
feat: 토큰 기반 페이지 접근 제한 및 리다이렉트 미들웨어 추가

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const token = req.cookies.get('REFRESH_KEY');
+  const path = req.nextUrl.pathname;
+  const isAuthPage = path.startsWith('/login') || path.startsWith('/signup');
+
+  if (!token && !isAuthPage) {
+    return NextResponse.redirect(new URL('/login', req.url));
+  }
+
+  if (token && isAuthPage) {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/chats/:path*',
+    '/login/:path*',
+    '/my/:path*',
+    '/notification/:path*',
+    '/password/request/:path*',
+    '/signup/:path*',
+  ],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
   "include": [
     "svg.d.ts",
     "next-env.d.ts",
+    "src/middleware.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     ".next/types/**/*.ts",


### PR DESCRIPTION
this fixes #115 

### 작업 내용
- [x] 비로그인 사용자의 `/my`, `/notification`, `/chats`, `/password/request` 페이지 접근 제한
  - [x] `/login` 페이지로 리다이렉트
- [x] 로그인 사용자의 `/login`, `/signup` 페이지 접근 제한
  - [x] `/` 페이지로 리다이렉트