### PR TITLE
feat: 게시글 목록에 거래 상태 표기, 채팅방에 거래 상세 및 수정 연동 추가

### DIFF
--- a/src/app/api/aladin/route.ts
+++ b/src/app/api/aladin/route.ts
@@ -19,8 +19,7 @@ export async function GET(req: NextRequest) {
     if (response.ok) {
       const item = data.item;
       const items = Array.isArray(item) ? item : item ? [item] : [];
-      console.log(items);
-      return new Response(JSON.stringify({ ...data, item: items }), {
+      return new Response(JSON.stringify(items), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -30,7 +29,6 @@ export async function GET(req: NextRequest) {
       });
     }
   } catch (error) {
-    console.log(error);
     return new Response(
       JSON.stringify({
         message: 'Internal Server Error',

--- a/src/entities/chat/api.ts
+++ b/src/entities/chat/api.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/shared/config/axios';
-import { Chat, ChatInfo, ChatMessage, getMessageRes, postMessageReq } from '.';
+import { Chat, ChatInfo, ChatMessage, postMessageReq } from '.';
 
 export const connectChat = (
   chatroomId: number,
@@ -53,7 +53,7 @@ export const postNewMessage = async ({
 
 export const getMessages = async (
   chatroomId: number,
-): Promise<getMessageRes> => {
+): Promise<ChatMessage[]> => {
   const { data } = await axiosInstance.get(`/chatrooms/${chatroomId}/messages`);
   return data;
 };

--- a/src/entities/chat/types.ts
+++ b/src/entities/chat/types.ts
@@ -1,5 +1,6 @@
 import { DetailImage, PostTradeStatus } from '../listing';
 import { UserProfileRes } from '../user';
+import { TradeStatus } from '../trade';
 
 export type ChatType = 'TEXT' | 'IMAGE' | 'SYSTEM';
 
@@ -22,7 +23,7 @@ export interface ChatInfo {
   title: string;
   trade: {
     id: number;
-    status: 'REQUESTED' | 'CANCELED' | 'COMPLETED';
+    status: TradeStatus;
   };
   post: ChatPost;
   partner: ChatUser;
@@ -32,11 +33,6 @@ export interface postMessageReq {
   chatroomId: number;
   message: string | null;
   fileNames: string[];
-}
-
-export interface getMessageRes {
-  messages: ChatMessage[];
-  hasNext: boolean;
 }
 
 interface BasicChat {

--- a/src/entities/listing/queries.ts
+++ b/src/entities/listing/queries.ts
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/navigation';
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query';
+import { queryClient } from '@/shared/lib';
 import {
   deleteLike,
   getFavorites,
@@ -13,7 +14,6 @@ import {
   patchListingReq,
   patchListing,
 } from '.';
-import { queryClient } from '@/shared/lib';
 
 export const useListingQuery = (filter: getPostsReq) => {
   return useInfiniteQuery({
@@ -71,10 +71,13 @@ type useLikeProps = {
   like: boolean;
 };
 
-export const useLikeMutation = () => {
+export const useLikeMutation = (postId: number) => {
   return useMutation<void, Error, useLikeProps>({
     mutationFn: async ({ postId, like }) => {
       return like ? postLike(postId) : deleteLike(postId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['listingDetail', postId] });
     },
   });
 };

--- a/src/entities/listing/types.ts
+++ b/src/entities/listing/types.ts
@@ -5,6 +5,7 @@ export type BookStatus = 'BEST' | 'HIGH' | 'MEDIUM' | 'LOW';
 export type PostTradeStatus = 'READY' | 'RESERVED' | 'COMPLETED';
 export type SortKey = 'RECENT' | 'OLD' | 'LOW_PRICE' | 'HIGH_PRICE';
 export type SearchKey = '통합' | '제목' | '저자';
+export type ParticipationType = TradeStatus | 'NONE' | 'OWNER';
 
 export interface GetPostsRes {
   totalCount: number;
@@ -34,6 +35,7 @@ export interface PostModel {
   thumbnailUrl: string;
   bookStatus: BookStatus;
   createdAt: string;
+  participation: ParticipationType;
 }
 
 export interface ListingDetailTrade {

--- a/src/entities/trade/queries.ts
+++ b/src/entities/trade/queries.ts
@@ -64,6 +64,9 @@ export const usePostTradeMutation = () => {
       await queryClient.invalidateQueries({
         queryKey: ['tradelist', 'SENT', ['REQUESTED', 'REJECTED']],
       });
+      await queryClient.invalidateQueries({
+        queryKey: ['listing'],
+      });
       if (myId) {
         await queryClient.invalidateQueries({ queryKey: ['bookcase', myId] });
       } else {
@@ -80,10 +83,11 @@ export const useTradeQuery = ({ key, status }: GetTradesReq) => {
   });
 };
 
-export const useTradeDetailQuery = (tradeId: number) => {
+export const useTradeDetailQuery = (tradeId?: number) => {
   return useQuery({
     queryKey: ['tradeDetail', tradeId],
-    queryFn: () => getTradeDetail(tradeId),
+    queryFn: () => getTradeDetail(tradeId!),
+    enabled: !!tradeId,
   });
 };
 

--- a/src/entities/trade/types.ts
+++ b/src/entities/trade/types.ts
@@ -68,10 +68,10 @@ interface PostSummary {
   cover: string;
 }
 
-interface TradeBook extends Bookcase {
+type TradeBook = Omit<Bookcase, 'isbn'> & {
   priceStandard: number;
   pubDate: string;
-}
+};
 
 interface TradeUser {
   id: string;

--- a/src/features/chat/ui/ChatRoom.styles.ts
+++ b/src/features/chat/ui/ChatRoom.styles.ts
@@ -72,8 +72,14 @@ export const DropdownItem = styled.div<{ $red?: boolean }>`
 
 export const Info = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: center;
   margin: 10px;
+`;
+
+export const InfoLeftSection = styled.div`
+  display: flex;
+  align-items: center;
   gap: 10px;
 `;
 
@@ -111,11 +117,25 @@ export const StatusText = styled.div`
 `;
 
 export const TitleText = styled.div`
-  font-size: 15px;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 200px;
+  width: 180px;
+`;
+
+export const DetailButton = styled.div`
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border: 1px solid ${({ theme }) => theme.colors.PRIMARY};
+  color: ${({ theme }) => theme.colors.PRIMARY};
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:active {
+    transform: scale(0.97);
+  }
 `;
 
 export const Chats = styled.div`

--- a/src/features/chat/ui/ChatRoom.tsx
+++ b/src/features/chat/ui/ChatRoom.tsx
@@ -2,6 +2,15 @@ import { useParams } from 'next/navigation';
 import { useTheme } from 'styled-components';
 import React, { useEffect, useRef, useState } from 'react';
 import { compareDate, formatDate, formatTime, queryClient } from '@/shared/lib';
+import { useFailedChatStore } from '../model/useFailedChatStore';
+import { useUploadImagesMutation } from '@/entities/files';
+import { useFABStore, useIsMobile } from '@/shared/model';
+import { DetailImage } from '@/entities/listing';
+import ChatRoomHeader from './ChatRoomHeader';
+import ChatRoomInfo from './ChatRoomInfo';
+import * as S from './ChatRoom.styles';
+import ChatImages from './ChatImages';
+import { Div } from './ChatWidget';
 import {
   ChatMessage,
   connectChat,
@@ -19,15 +28,6 @@ import {
   SendIcon,
   SendReverseIcon,
 } from '@/shared/assets/icons';
-import { useFailedChatStore } from '../model/useFailedChatStore';
-import { useUploadImagesMutation } from '@/entities/files';
-import { useFABStore, useIsMobile } from '@/shared/model';
-import { DetailImage } from '@/entities/listing';
-import ChatRoomHeader from './ChatRoomHeader';
-import ChatRoomInfo from './ChatRoomInfo';
-import * as S from './ChatRoom.styles';
-import ChatImages from './ChatImages';
-import { Div } from './ChatWidget';
 
 const ChatRoom = () => {
   const theme = useTheme();
@@ -63,7 +63,7 @@ const ChatRoom = () => {
   useEffect(() => {
     if (!chatData || !chatRoomId) return;
     const failed = failedChats[chatRoomId] ?? [];
-    setChats([...chatData.messages, ...failed]);
+    setChats([...chatData, ...failed]);
   }, [chatData, chatRoomId, failedChats]);
 
   useEffect(() => {
@@ -264,6 +264,7 @@ const ChatRoom = () => {
       />
       <Div />
       <ChatRoomInfo
+        tradeId={chatInfo.trade.id}
         post={chatInfo.post}
         isOpenDropdown={isOpenDropdown}
         onClick={() => setIsOpenDropdown(true)}

--- a/src/features/chat/ui/ChatRoomInfo.tsx
+++ b/src/features/chat/ui/ChatRoomInfo.tsx
@@ -1,54 +1,121 @@
 import Image from 'next/image';
+import { useState } from 'react';
 import { useTheme } from 'styled-components';
+import TradeDetail from '@/features/trade/ui/TradeDetail';
+import { useTradeDetailQuery } from '@/entities/trade';
 import { DropdownIcon } from '@/shared/assets/icons';
+import { TradeRequest } from '@/features/trade/ui';
+import { Button, ModalLayout } from '@/shared/ui';
 import { chatPostStatusMap } from '@/shared/lib';
 import { useMyQuery } from '@/entities/user';
 import { ChatPost } from '@/entities/chat';
 import * as S from './ChatRoom.styles';
 
 interface ChatRoomInfoProps {
+  tradeId: number;
   post: ChatPost;
   isOpenDropdown: boolean;
   onClick: () => void;
 }
-const ChatRoomInfo = ({ post, isOpenDropdown, onClick }: ChatRoomInfoProps) => {
+
+const ChatRoomInfo = ({
+  tradeId,
+  post,
+  isOpenDropdown,
+  onClick,
+}: ChatRoomInfoProps) => {
   const theme = useTheme();
   const { data } = useMyQuery();
   const isSeller = data?.id === post.sellerId;
+  const [openDetail, setOpenDetail] = useState(false);
+  const [openEdit, setOpenEdit] = useState(false);
+  const { data: tradeData } = useTradeDetailQuery(tradeId);
+
+  function handleClickEdit() {
+    setOpenDetail(false);
+    setOpenEdit(true);
+  }
+
+  function handleClickCloseEdit() {
+    setOpenEdit(false);
+    setOpenDetail(true);
+  }
+
+  function handleClickCloseAll() {
+    setOpenEdit(false);
+    setOpenDetail(false);
+  }
+
   function handleClickStatus() {
     onClick();
   }
   return (
-    <S.Info>
-      <S.ImageWrapper>
-        <Image
-          loader={() => post.thumbnailUrl}
-          src={post.thumbnailUrl}
-          alt='책 대표사진'
-          width={40}
-          height={40}
-          unoptimized
-        />
-      </S.ImageWrapper>
-      <div>
-        <S.InfoTop>
-          <S.Status
-            onClick={isSeller ? handleClickStatus : undefined}
-            $clickable={isSeller}>
-            <S.StatusText>{chatPostStatusMap[post.status]}</S.StatusText>
-            {isSeller && <DropdownIcon fill={theme.colors.BLACK} />}
-            {isOpenDropdown && (
-              <S.DropdownList>
-                <S.DropdownItem>판매중</S.DropdownItem>
-                <S.DropdownItem>거래완료</S.DropdownItem>
-              </S.DropdownList>
-            )}
-          </S.Status>
-          <S.TitleText>{post.title}</S.TitleText>
-        </S.InfoTop>
-        <S.InfoBottom>{post.sellPrice.toLocaleString()}원</S.InfoBottom>
-      </div>
-    </S.Info>
+    <>
+      <S.Info>
+        <S.InfoLeftSection>
+          <S.ImageWrapper>
+            <Image
+              loader={() => post.thumbnailUrl}
+              src={post.thumbnailUrl}
+              alt='책 대표사진'
+              width={40}
+              height={40}
+              unoptimized
+            />
+          </S.ImageWrapper>
+          <div>
+            <S.InfoTop>
+              <S.Status
+                onClick={isSeller ? handleClickStatus : undefined}
+                $clickable={isSeller}>
+                <S.StatusText>{chatPostStatusMap[post.status]}</S.StatusText>
+                {isSeller && <DropdownIcon fill={theme.colors.BLACK} />}
+                {isOpenDropdown && (
+                  <S.DropdownList>
+                    <S.DropdownItem>판매중</S.DropdownItem>
+                    <S.DropdownItem>예약중</S.DropdownItem>
+                    <S.DropdownItem>거래완료</S.DropdownItem>
+                  </S.DropdownList>
+                )}
+              </S.Status>
+              <S.TitleText>{post.title}</S.TitleText>
+            </S.InfoTop>
+            <S.InfoBottom>{post.sellPrice.toLocaleString()}원</S.InfoBottom>
+          </div>
+        </S.InfoLeftSection>
+        <S.DetailButton onClick={() => setOpenDetail(true)}>
+          거래 상세
+        </S.DetailButton>
+      </S.Info>
+      {openDetail && tradeData && (
+        <ModalLayout
+          isOpen={openDetail}
+          title={`${tradeData?.buyer.nickname}님의 거래 요청`}
+          onClose={() => setOpenDetail(false)}>
+          <TradeDetail
+            type={isSeller ? 'RESPONSE' : 'REQUEST'}
+            trade={tradeData}
+          />
+          <Button text='내 거래 물품 변경' onClick={handleClickEdit} />
+        </ModalLayout>
+      )}
+      {openEdit && (
+        <ModalLayout
+          isOpen={openEdit}
+          title='교환할 책을 선택해 주세요'
+          onClose={handleClickCloseEdit}>
+          <TradeRequest
+            tradeId={tradeId}
+            onClose={handleClickCloseAll}
+            prevItems={
+              isSeller
+                ? tradeData?.seller.item.map((i) => i.id)
+                : tradeData?.buyer.item.map((i) => i.id)
+            }
+          />
+        </ModalLayout>
+      )}
+    </>
   );
 };
 export default ChatRoomInfo;

--- a/src/features/listing/model/useFilterStore.ts
+++ b/src/features/listing/model/useFilterStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 import { BookStatus, SearchKey, SortKey } from '@/entities/listing/types';
 
 type FilterState = {
@@ -22,32 +23,41 @@ type FilterState = {
   resetFilters: () => void;
 };
 
-export const useFilterStore = create<FilterState>((set) => ({
-  key: '통합',
-  keyword: null,
-  emdId: undefined,
-  isAvailableOnly: false,
-  categoryId: null,
-  bookStatus: null,
-  priceRange: null,
-  sort: 'RECENT',
-  setKey: (k) => set({ key: k }),
-  setKeyword: (k) => set({ keyword: k }),
-  setEmdId: (e) => set({ emdId: e }),
-  setIsAvailableOnly: (b) => set({ isAvailableOnly: b }),
-  toggleIsAvailableOnly: () =>
-    set((state) => ({ isAvailableOnly: !state.isAvailableOnly })),
-  setCategoryId: (c) => set({ categoryId: c }),
-  setBookStatus: (b) => set({ bookStatus: b }),
-  setPriceRange: (p) => set({ priceRange: p }),
-  setSort: (s) => set({ sort: s }),
-  resetFilters: () =>
-    set({
+export const useFilterStore = create<FilterState>()(
+  persist(
+    (set) => ({
       key: '통합',
       keyword: null,
+      emdId: undefined,
       isAvailableOnly: false,
       categoryId: null,
       bookStatus: null,
       priceRange: null,
+      sort: 'RECENT',
+      setKey: (k) => set({ key: k }),
+      setKeyword: (k) => set({ keyword: k }),
+      setEmdId: (e) => set({ emdId: e }),
+      setIsAvailableOnly: (b) => set({ isAvailableOnly: b }),
+      toggleIsAvailableOnly: () =>
+        set((state) => ({ isAvailableOnly: !state.isAvailableOnly })),
+      setCategoryId: (c) => set({ categoryId: c }),
+      setBookStatus: (b) => set({ bookStatus: b }),
+      setPriceRange: (p) => set({ priceRange: p }),
+      setSort: (s) => set({ sort: s }),
+      resetFilters: () =>
+        set({
+          key: '통합',
+          keyword: null,
+          isAvailableOnly: false,
+          categoryId: null,
+          bookStatus: null,
+          priceRange: null,
+        }),
     }),
-}));
+    {
+      name: 'filter-storage',
+      storage: createJSONStorage(() => sessionStorage),
+      partialize: (state) => ({ emdId: state.emdId }),
+    },
+  ),
+);

--- a/src/features/listing/ui/detail/ListingDetail.tsx
+++ b/src/features/listing/ui/detail/ListingDetail.tsx
@@ -1,19 +1,13 @@
 'use client';
 
-import { toast } from 'react-toastify';
 import { useEffect, useState } from 'react';
-import { useTheme } from 'styled-components';
-
-import { useLikeMutation, useListingDetailQuery } from '@/entities/listing';
 import { bookStatusMap, convertDiffToString } from '@/shared/lib';
 import { LoadingContainer } from '@/shared/ui/LoadingIndicator';
-import { calcDistance, getCategoryNameById } from '../../lib';
-import { LoadingIndicator, ModalLayout } from '@/shared/ui';
+import { useListingDetailQuery } from '@/entities/listing';
 import BookItem from '@/features/user/ui/profile/BookItem';
-import { TradeRequest } from '@/features/trade/ui';
-import { LikeIcon } from '@/shared/assets/icons';
-import { useMyQuery } from '@/entities/user';
-import { colors } from '@/shared/constants';
+import ListingDetailActions from './ListingDetailActions';
+import { getCategoryNameById } from '../../lib';
+import { LoadingIndicator } from '@/shared/ui';
 import * as S from './ListingDetail.styles';
 import ImageCarousel from './ImageCarousel';
 import UserInfo from './UserInfo';
@@ -25,69 +19,14 @@ import {
 } from '@/features/user/ui/profile/Interests';
 
 const ListingDetail = ({ id }: { id: number }) => {
-  const theme = useTheme();
-  const { data: mydata } = useMyQuery();
   const { data, isPending } = useListingDetailQuery(id);
-  const [liked, setLiked] = useState<boolean | undefined>(undefined);
-  const [originalLiked, setOriginalLiked] = useState<boolean | undefined>(
-    undefined,
-  );
   const [likeCount, setLikeCount] = useState<number | undefined>(undefined);
-  const { mutate: controlLike } = useLikeMutation();
-  const [openTradeRequest, setOpenTradeRequest] = useState(false);
-
-  function handleLike() {
-    if (!data || !mydata) {
-      toast.info('로그인 후 이용해 주세요');
-      return;
-    }
-    if (data?.isOwner) {
-      toast.info('본인의 게시글은 찜할 수 없어요');
-      return;
-    }
-    setLiked((prev) => !prev);
-  }
-
-  function handleClickExchange() {
-    if (!data || !mydata) {
-      toast.info('로그인 후 이용해 주세요');
-      return;
-    }
-    if (data.isOwner) {
-      toast.info('자신의 게시글에는 교환을 신청할 수 없어요');
-      return;
-    }
-    setOpenTradeRequest(true);
-  }
 
   useEffect(() => {
     if (data) {
-      setLiked(data.isFavorite);
-      setOriginalLiked(data.isFavorite);
       setLikeCount(data.scrapCount);
     }
   }, [data]);
-
-  useEffect(() => {
-    const debounce = setTimeout(() => {
-      if (liked !== undefined && liked !== originalLiked) {
-        controlLike(
-          { postId: id, like: liked },
-          {
-            onSuccess: () => {
-              setOriginalLiked(liked);
-              setLikeCount((prev) => {
-                const safePrev = prev ?? 0;
-                return liked ? safePrev + 1 : safePrev - 1;
-              });
-            },
-          },
-        );
-      }
-    }, 500);
-
-    return () => clearTimeout(debounce);
-  }, [liked]);
 
   return (
     <>
@@ -131,24 +70,8 @@ const ListingDetail = ({ id }: { id: number }) => {
                 pubDate={data.book.pubDate}
                 description={data.book.description}
               />
-              {!data.isOwner && (
-                <S.ButtonRow>
-                  <S.Button
-                    variant={liked ? 'outline-primary' : 'outline-gray'}
-                    onClick={handleLike}>
-                    <LikeIcon
-                      fill={liked ? colors.light.PRIMARY : 'none'}
-                      stroke={
-                        !liked ? theme.colors.GRAY_500 : theme.colors.PRIMARY
-                      }
-                      strokeWidth={1.5}
-                    />
-                    찜하기
-                  </S.Button>
-                  <S.Button variant='primary' onClick={handleClickExchange}>
-                    교환 신청
-                  </S.Button>
-                </S.ButtonRow>
+              {data && !data.isOwner && (
+                <ListingDetailActions data={data} postId={id} />
               )}
               {data.wishOnly && (
                 <S.InfoText>
@@ -182,18 +105,6 @@ const ListingDetail = ({ id }: { id: number }) => {
         <LoadingContainer>
           <LoadingIndicator />
         </LoadingContainer>
-      )}
-      {openTradeRequest && mydata && data && (
-        <ModalLayout
-          isOpen={openTradeRequest}
-          title='교환할 책을 선택해 주세요'
-          onClose={() => setOpenTradeRequest(false)}>
-          <TradeRequest
-            isFar={calcDistance(mydata.area.emdId, data.writer.emdId)}
-            postId={id}
-            onClose={() => setOpenTradeRequest(false)}
-          />
-        </ModalLayout>
       )}
     </>
   );

--- a/src/features/listing/ui/detail/ListingDetailActions.tsx
+++ b/src/features/listing/ui/detail/ListingDetailActions.tsx
@@ -1,0 +1,113 @@
+import { toast } from 'react-toastify';
+import { useEffect, useState } from 'react';
+import { useTheme } from 'styled-components';
+import { ListingDetailRes, useLikeMutation } from '@/entities/listing';
+import { useTradeDetailQuery } from '@/entities/trade';
+import { TradeRequest } from '@/features/trade/ui';
+import { LikeIcon } from '@/shared/assets/icons';
+import { useMyQuery } from '@/entities/user';
+import * as S from './ListingDetail.styles';
+import { colors } from '@/shared/constants';
+import { ModalLayout } from '@/shared/ui';
+import { calcDistance } from '../../lib';
+
+interface ListingDetailActionsProps {
+  data: ListingDetailRes;
+  postId: number;
+}
+
+const ListingDetailActions = ({ data, postId }: ListingDetailActionsProps) => {
+  const theme = useTheme();
+  const { data: myData } = useMyQuery();
+  const [liked, setLiked] = useState<boolean | undefined>(undefined);
+  const [originalLiked, setOriginalLiked] = useState<boolean | undefined>(
+    undefined,
+  );
+  const { mutate: controlLike } = useLikeMutation(postId);
+  const [openTradeRequest, setOpenTradeRequest] = useState(false);
+  const tradeId = data.trade?.id;
+  const { data: tradeData } = useTradeDetailQuery(tradeId);
+
+  function checkLogin() {
+    if (!data || !myData) {
+      toast.info('로그인 후 이용해 주세요');
+      return false;
+    }
+    return true;
+  }
+
+  function handleLike() {
+    if (!checkLogin()) return;
+    if (data.isOwner) {
+      toast.info('본인의 게시글은 찜할 수 없어요');
+      return;
+    }
+    setLiked((prev) => !prev);
+  }
+
+  function handleClickExchange() {
+    if (!checkLogin()) return;
+    if (data.isOwner) {
+      toast.info('자신의 게시글에는 교환을 신청할 수 없어요');
+      return;
+    }
+    setOpenTradeRequest(true);
+  }
+
+  useEffect(() => {
+    setLiked(data.isFavorite);
+    setOriginalLiked(data.isFavorite);
+  }, [data.isFavorite]);
+
+  useEffect(() => {
+    const debounce = setTimeout(() => {
+      if (liked !== undefined && liked !== originalLiked) {
+        controlLike(
+          { postId, like: liked },
+          {
+            onSuccess: () => {
+              setOriginalLiked(liked);
+            },
+          },
+        );
+      }
+    }, 500);
+
+    return () => clearTimeout(debounce);
+  }, [liked, originalLiked]);
+
+  return (
+    <>
+      <S.ButtonRow>
+        <S.Button
+          variant={liked ? 'outline-primary' : 'outline-gray'}
+          onClick={handleLike}>
+          <LikeIcon
+            fill={liked ? colors.light.PRIMARY : 'none'}
+            stroke={!liked ? theme.colors.GRAY_500 : theme.colors.PRIMARY}
+            strokeWidth={1.5}
+          />
+          찜하기
+        </S.Button>
+        <S.Button variant='primary' onClick={handleClickExchange}>
+          교환 신청
+        </S.Button>
+      </S.ButtonRow>
+      {openTradeRequest && myData && (
+        <ModalLayout
+          isOpen={openTradeRequest}
+          title='교환할 책을 선택해 주세요'
+          onClose={() => setOpenTradeRequest(false)}>
+          <TradeRequest
+            isFar={calcDistance(myData.area.emdId, data.writer.emdId)}
+            postId={postId}
+            onClose={() => setOpenTradeRequest(false)}
+            tradeId={data.trade ? data.trade.id : undefined}
+            prevItems={tradeData?.buyer.item.map((i) => i.id)}
+          />
+        </ModalLayout>
+      )}
+    </>
+  );
+};
+export default ListingDetailActions;

--- a/src/features/listing/ui/main/filter/ListingAreaButton.tsx
+++ b/src/features/listing/ui/main/filter/ListingAreaButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DropdownIconSm, PinIcon } from '@/shared/assets/icons';
 import { ModalLayout, SelectAreaSection } from '@/shared/ui';
 import emd_areas from '@/shared/constants/emd_areas.json';
@@ -16,13 +16,11 @@ const ListingAreaButton = () => {
   const { setEmdId } = useFilterStore();
   const [selectedEmdId, setSelectedEmdId] = useState<number>();
 
-  const selectedName = useMemo(() => {
-    const match = emd_areas.find((e) => e.id === emdId);
-    return match?.name ?? '선택안함';
-  }, [emdId]);
+  const selectedName =
+    emd_areas.find((e) => e.id === emdId)?.name ?? '선택안함';
 
   useEffect(() => {
-    if (myData) setEmdId(myData.area.emdId);
+    if (!emdId && myData) setEmdId(myData.area.emdId);
   }, [myData]);
 
   function handleApply() {

--- a/src/features/listing/ui/main/filter/ListingFilterButton.tsx
+++ b/src/features/listing/ui/main/filter/ListingFilterButton.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { FilterIcon } from '@/shared/assets/icons';
-import * as S from './ListingControls.styles';
-import { Button, ModalLayout } from '@/shared/ui';
-import { useRef, useState } from 'react';
-import FilterContent from './FilterContent';
-import { BookStatus } from '@/entities/listing/types';
 import styled from 'styled-components';
+import { useRef, useState } from 'react';
+import { BookStatus } from '@/entities/listing/types';
+import { FilterIcon } from '@/shared/assets/icons';
+import { Button, ModalLayout } from '@/shared/ui';
 import { useFilterStore } from '../../../model';
-import { colors } from '@/shared/constants';
+import * as S from './ListingControls.styles';
+import FilterContent from './FilterContent';
 
 export interface FilterStatus {
   isAvailableOnly: boolean;
@@ -16,6 +15,7 @@ export interface FilterStatus {
   bookStatus: BookStatus | null;
   priceRange: number | null;
 }
+
 const ListingFilterButton = () => {
   const [isOpen, setIsOpen] = useState(false);
   const isAvailableOnly = useFilterStore((state) => state.isAvailableOnly);

--- a/src/features/listing/ui/main/list/ListingCard.styles.ts
+++ b/src/features/listing/ui/main/list/ListingCard.styles.ts
@@ -9,7 +9,7 @@ const Z_OVERLAY_STATUS = 13;
 const Z_TAG_WRAPPER = 10;
 
 interface OverlayProps {
-  status: PostTradeStatus;
+  $status: PostTradeStatus;
 }
 
 export const CardContainer = styled(Link)`
@@ -62,18 +62,25 @@ export const Overlay = styled.div`
 
 export const OverlayDim = styled.div<OverlayProps>`
   position: absolute;
-  background-color: ${({ status }) =>
-    status === 'READY' ? 'transparent' : 'rgba(0, 0, 0, 0.7)'};
+  background-color: ${({ $status }) =>
+    $status === 'READY' ? 'transparent' : 'rgba(0, 0, 0, 0.7)'};
   z-index: ${Z_OVERLAY_DIM};
   width: 100%;
   height: 100%;
 `;
 
-export const TagWrapper = styled.div`
+const TagWrapper = styled.div`
   position: absolute;
   top: 10px;
-  right: 10px;
   z-index: ${Z_TAG_WRAPPER};
+`;
+
+export const RightTagWrapper = styled(TagWrapper)`
+  right: 10px;
+`;
+
+export const LeftTagWrapper = styled(TagWrapper)`
+  left: 10px;
 `;
 
 export const OverlayStatusText = styled.div`

--- a/src/features/listing/ui/main/list/ListingCard.tsx
+++ b/src/features/listing/ui/main/list/ListingCard.tsx
@@ -10,22 +10,30 @@ import * as S from './ListingCard.styles';
 const ListingCard = ({ data }: { data: PostModel }) => {
   const categoryName = getCategoryNameById(data.categoryId);
   const time = convertDiffToString(data.createdAt);
+
   return (
     <S.CardContainer href={`/listings/${data.id}`}>
       <S.ImageWrapper>
         <S.Overlay>
-          <S.OverlayDim status={data.status} />
+          <S.OverlayDim $status={data.status} />
           {data.status !== 'READY' && (
             <S.OverlayStatusText>
               {postStatusMap[data.status]}
             </S.OverlayStatusText>
           )}
-          <S.TagWrapper>
-            <ListingCardTag status={data.bookStatus} />
-          </S.TagWrapper>
+          {data.participation === 'CANCELED' ||
+            data.participation === 'REQUESTED' ||
+            data.participation === 'ACCEPTED' ||
+            (data.participation === 'REJECTED' && (
+              <S.LeftTagWrapper>
+                <ListingCardTag $tradeStatus={data.participation} />
+              </S.LeftTagWrapper>
+            ))}
+          <S.RightTagWrapper>
+            <ListingCardTag $bookStatus={data.bookStatus} />
+          </S.RightTagWrapper>
         </S.Overlay>
         <Image
-          loader={() => data.thumbnailUrl}
           src={data.thumbnailUrl}
           alt='책 대표사진'
           fill

--- a/src/features/listing/ui/main/list/ListingCard.tsx
+++ b/src/features/listing/ui/main/list/ListingCard.tsx
@@ -21,14 +21,14 @@ const ListingCard = ({ data }: { data: PostModel }) => {
               {postStatusMap[data.status]}
             </S.OverlayStatusText>
           )}
-          {data.participation === 'CANCELED' ||
+          {(data.participation === 'CANCELED' ||
             data.participation === 'REQUESTED' ||
             data.participation === 'ACCEPTED' ||
-            (data.participation === 'REJECTED' && (
-              <S.LeftTagWrapper>
-                <ListingCardTag $tradeStatus={data.participation} />
-              </S.LeftTagWrapper>
-            ))}
+            data.participation === 'REJECTED') && (
+            <S.LeftTagWrapper>
+              <ListingCardTag $tradeStatus={data.participation} />
+            </S.LeftTagWrapper>
+          )}
           <S.RightTagWrapper>
             <ListingCardTag $bookStatus={data.bookStatus} />
           </S.RightTagWrapper>

--- a/src/features/listing/ui/main/list/ListingCardTag.tsx
+++ b/src/features/listing/ui/main/list/ListingCardTag.tsx
@@ -1,27 +1,38 @@
 import styled from 'styled-components';
 import { colors } from '../../../../../shared/constants';
-import { bookStatusMap } from '@/shared/lib';
+import { bookStatusMap, tradeStatusMap } from '@/shared/lib';
 import { BookStatus } from '@/entities/listing/types';
+import { TradeStatus } from '@/entities/trade';
 
-const ListingCardTag = ({ status }: { status: BookStatus }) => {
-  const text = bookStatusMap[status];
-  return <Container status={status}>#{text}</Container>;
+type TagTradeStatus = Exclude<TradeStatus, 'RESERVED' | 'COMPLETED'>;
+
+type TagProps =
+  | { $bookStatus: BookStatus; $tradeStatus?: never }
+  | { $bookStatus?: never; $tradeStatus: TagTradeStatus };
+
+const ListingCardTag = ({ $bookStatus, $tradeStatus }: TagProps) => {
+  const text = $bookStatus
+    ? bookStatusMap[$bookStatus]
+    : tradeStatusMap[$tradeStatus];
+
+  const backgroundColor = $bookStatus
+    ? colors.light.BOOK_STATUS[$bookStatus]
+    : 'rgba(0,0,0,0.5)';
+
+  return <Container $backgroundColor={backgroundColor}>#{text}</Container>;
 };
 
 export default ListingCardTag;
 
-interface TagProps {
-  status: BookStatus;
-}
-const Container = styled.div<TagProps>`
-  background-color: ${({ status }) => colors.light.BOOK_STATUS[status]};
+const Container = styled.div<{ $backgroundColor: string }>`
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
   padding: 3px 5px;
   border-radius: 10px;
   font-size: 12px;
   font-weight: 600;
   color: ${colors.light.WHITE};
   box-shadow: 2px 2px 3px rgba(0, 0, 0, 0.3);
-  @media (max-width: 480px) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
     font-size: 10px;
   }
 `;

--- a/src/features/trade/ui/TradeCard/index.tsx
+++ b/src/features/trade/ui/TradeCard/index.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState } from 'react';
+import TradeDetailContainer from '../TradeDetail/TradeDetailContainer';
 import { useTradeActions } from '../../model/useTradeActions';
 import { SwitchIcon } from '@/shared/assets/icons';
 import { ModalLayout } from '@/shared/ui';
 import TradeActions from './TradeActions';
-import TradeDetail from '../TradeDetail';
 import TradeBook from './TradeBook';
 import { TradeRequest } from '..';
 import {
@@ -80,7 +80,7 @@ const TradeCard = ({
           isOpen={openDetail}
           title={`${trade.buyer.nickname}님의 거래 요청`}
           onClose={() => setOpenDetail(false)}>
-          <TradeDetail
+          <TradeDetailContainer
             type={type}
             query={query}
             tradeId={trade.id}

--- a/src/features/trade/ui/TradeDetail/TradeDetailContainer.tsx
+++ b/src/features/trade/ui/TradeDetail/TradeDetailContainer.tsx
@@ -1,0 +1,53 @@
+import {
+  GetTradesReq,
+  TradeStatus,
+  useTradeDetailQuery,
+} from '@/entities/trade';
+import { ButtonSection, Container, InfoText } from './styles';
+import { useTradeActions } from '../../model/useTradeActions';
+import TradeActions from '../TradeCard/TradeActions';
+import TradeDetail from '.';
+
+const TradeDetailContainer = ({
+  type,
+  query,
+  tradeId,
+  status,
+  handleEdit,
+}: {
+  type: 'REQUEST' | 'RESPONSE';
+  query: GetTradesReq;
+  tradeId: number;
+  status: TradeStatus;
+  handleEdit: () => void;
+}) => {
+  const { data: trade } = useTradeDetailQuery(tradeId);
+  const { handleAccept, handleReject, handleCancel, handleDelete } =
+    useTradeActions({
+      tradeId,
+      ...query,
+    });
+  return (
+    <Container>
+      {trade && <TradeDetail type={type} trade={trade} />}
+      <ButtonSection>
+        <TradeActions
+          type={type}
+          status={status}
+          onAccept={handleAccept}
+          onReject={handleReject}
+          onCancel={handleCancel}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+      </ButtonSection>
+      {type === 'RESPONSE' && (
+        <InfoText>
+          *거절 시 되돌릴 수 없으며, 수락 시 채팅방이 생성됩니다.
+        </InfoText>
+      )}
+    </Container>
+  );
+};
+
+export default TradeDetailContainer;

--- a/src/features/trade/ui/TradeDetail/index.tsx
+++ b/src/features/trade/ui/TradeDetail/index.tsx
@@ -1,16 +1,8 @@
-import { useTradeActions } from '../../model/useTradeActions';
 import TradeDetailBookItem from './TradeDetailBookItem';
-import TradeActions from '../TradeCard/TradeActions';
+import { GetTradeDetailRes } from '@/entities/trade';
 import { SwitchIcon } from '@/shared/assets/icons';
 import {
-  GetTradesReq,
-  TradeStatus,
-  useTradeDetailQuery,
-} from '@/entities/trade';
-import {
-  ButtonSection,
   BooksSection,
-  Container,
   InfoText,
   WorthSection,
   SectionTitle,
@@ -20,29 +12,17 @@ import {
 
 const TradeDetail = ({
   type,
-  query,
-  tradeId,
-  status,
-  handleEdit,
+  trade,
 }: {
   type: 'REQUEST' | 'RESPONSE';
-  query: GetTradesReq;
-  tradeId: number;
-  status: TradeStatus;
-  handleEdit: () => void;
+  trade: GetTradeDetailRes;
 }) => {
-  const { handleAccept, handleReject, handleCancel, handleDelete } =
-    useTradeActions({
-      tradeId,
-      ...query,
-    });
-  const { data: trade } = useTradeDetailQuery(tradeId);
   if (!trade) return;
 
   const other = type === 'REQUEST' ? trade.seller : trade.buyer;
   const me = type === 'REQUEST' ? trade.buyer : trade.seller;
   return (
-    <Container>
+    <>
       <BooksSection>
         <SectionTitle>상대방의 거래 도서</SectionTitle>
         {other.item.map((book) => (
@@ -65,23 +45,7 @@ const TradeDetail = ({
           <WorthText>{me.worth.toLocaleString()}원</WorthText>
         </Worth>
       </WorthSection>
-      <ButtonSection>
-        <TradeActions
-          type={type}
-          status={status}
-          onAccept={handleAccept}
-          onReject={handleReject}
-          onCancel={handleCancel}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-        />
-      </ButtonSection>
-      {type === 'RESPONSE' && (
-        <InfoText>
-          *거절 시 되돌릴 수 없으며, 수락 시 채팅방이 생성됩니다.
-        </InfoText>
-      )}
-    </Container>
+    </>
   );
 };
 

--- a/src/features/user/ui/My.tsx
+++ b/src/features/user/ui/My.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import Profile from './Profile';
+import { useEffect, useState } from 'react';
+import { LocalErrorBoundary } from '@/shared/lib';
 import MyFavorite from './MyFavorite';
+import Profile from './Profile';
 import MyTrade from './MyTrade';
 import MyBook from './MyBook';
 import MyTab from './MyTab';
@@ -30,7 +31,9 @@ const My = () => {
       {selected === 0 ? (
         <Profile />
       ) : selected === 1 ? (
-        <MyTrade />
+        <LocalErrorBoundary>
+          <MyTrade />
+        </LocalErrorBoundary>
       ) : selected === 2 ? (
         <MyFavorite />
       ) : (

--- a/src/features/user/ui/MyTrade.tsx
+++ b/src/features/user/ui/MyTrade.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { GetTradesReq, useTradeQuery } from '@/entities/trade';
-import { LocalErrorBoundary } from '@/shared/lib';
 import { TradeCard } from '@/features/trade/ui';
 import { LoadingIndicator } from '@/shared/ui';
 import SubTab from './SubTab';
@@ -34,35 +33,33 @@ const MyTrade = () => {
         selected={selectedSubTab}
         onChange={handleChangeSubTab}
       />
-      <LocalErrorBoundary>
-        {isPending ? (
-          <ContentsContainer>
-            <LoadingIndicator />
-          </ContentsContainer>
-        ) : data && data.trades.length <= 0 ? (
-          <ContentsContainer>
-            <EmptyText>
-              {selectedSubTab === 0
-                ? '받은 제안이 없습니다.'
-                : '보낸 제안이 없습니다.'}
-            </EmptyText>
-          </ContentsContainer>
-        ) : (
-          data &&
-          data.trades && (
-            <TradeWrapper>
-              {data.trades.map((trade) => (
-                <TradeCard
-                  key={trade.id}
-                  trade={trade}
-                  type={selectedSubTab === 0 ? 'RESPONSE' : 'REQUEST'}
-                  query={selectedSubTab === 0 ? resQuery : reqQuery}
-                />
-              ))}
-            </TradeWrapper>
-          )
-        )}
-      </LocalErrorBoundary>
+      {isPending ? (
+        <ContentsContainer>
+          <LoadingIndicator />
+        </ContentsContainer>
+      ) : data && data.trades.length <= 0 ? (
+        <ContentsContainer>
+          <EmptyText>
+            {selectedSubTab === 0
+              ? '받은 제안이 없습니다.'
+              : '보낸 제안이 없습니다.'}
+          </EmptyText>
+        </ContentsContainer>
+      ) : (
+        data &&
+        data.trades && (
+          <TradeWrapper>
+            {data.trades.map((trade) => (
+              <TradeCard
+                key={trade.id}
+                trade={trade}
+                type={selectedSubTab === 0 ? 'RESPONSE' : 'REQUEST'}
+                query={selectedSubTab === 0 ? resQuery : reqQuery}
+              />
+            ))}
+          </TradeWrapper>
+        )
+      )}
     </div>
   );
 };

--- a/src/features/user/ui/profile/ProfileInfoSection.tsx
+++ b/src/features/user/ui/profile/ProfileInfoSection.tsx
@@ -43,7 +43,6 @@ const ProfileInfoSection = ({
   const [emdId, setEmdId] = useState<number>(defaultArea.emdId);
   const [interests, setInterests] = useState<string[]>(defaultInterests);
   const { mutate: changeMyInfoMutation } = useMyInfoMutation();
-  const { handleAreaVerify } = useAreaVerify();
 
   const normalize = (str: string) => str.trim().toLowerCase();
 
@@ -76,10 +75,11 @@ const ProfileInfoSection = ({
     setInterests(defaultInterests);
   }
 
-  function handleRecertification() {
+  async function handleRecertification() {
     if (!emdId || defaultArea.emdId !== emdId) return;
-    handleAreaVerify(emdId);
+    updateLocation();
   }
+
   async function handleSaveEdit() {
     const interestSet = new Set(interests);
     const isSameInterest =
@@ -97,23 +97,28 @@ const ProfileInfoSection = ({
           interests,
         });
       } else if (emdId) {
-        const pos = await getCurrentPosition();
-        if (!pos) return;
-        const { lat, lon } = pos;
-        changeMyInfoMutation({
-          nickname,
-          emdId,
-          areaAuthenticate: true,
-          lat,
-          lon,
-          interests,
-        });
+        updateLocation();
       }
     } else {
       toast.info('변경 사항이 없습니다.');
       setEditMode(false);
     }
   }
+
+  async function updateLocation() {
+    const pos = await getCurrentPosition();
+    if (!pos) return;
+    const { lat, lon } = pos;
+    changeMyInfoMutation({
+      nickname,
+      emdId,
+      areaAuthenticate: true,
+      lat,
+      lon,
+      interests,
+    });
+  }
+
   return (
     <S.PriofileSectionContainer>
       {defaultProfileImageUrl === null && (

--- a/src/shared/lib/postTextMap.ts
+++ b/src/shared/lib/postTextMap.ts
@@ -29,3 +29,10 @@ export const sortMap = {
   LOW_PRICE: '낮은가격순',
   HIGH_PRICE: '높은가격순',
 } as const;
+
+export const tradeStatusMap = {
+  CANCELED: '취소됨',
+  REQUESTED: '요청중',
+  ACCEPTED: '거래중',
+  REJECTED: '거절됨',
+} as const;

--- a/src/shared/ui/LoadingIndicator.tsx
+++ b/src/shared/ui/LoadingIndicator.tsx
@@ -9,7 +9,7 @@ export const LoadingIndicator = ({
   return (
     <Container aria-label='로딩'>
       {Array.from(text).map((char, idx) => (
-        <Char key={idx} delay={idx * 0.1}>
+        <Char key={idx} $delay={idx * 0.1}>
           {char}
         </Char>
       ))}
@@ -29,16 +29,16 @@ const Container = styled.div`
   color: ${({ theme }) => theme.colors.GRAY_700};
 `;
 
-const Char = styled.span<{ delay: number }>`
+const Char = styled.span<{ $delay: number }>`
   display: inline-block;
   animation: ${wave} 1s infinite ease-in-out;
-  animation-delay: ${({ delay }) => `${delay}s`};
+  animation-delay: ${({ $delay }) => `${$delay}s`};
 `;
 
 export const LoadingContainer = styled.div`
-  width:100%;
+  width: 100%;
   height: 100%;
-  display:flex:
-  justify-content:center;
+  display: flex;
+  justify-content: center;
   align-items: center;
 `;


### PR DESCRIPTION
this closes #143

### 작업 내용
- [x] 게시글 목록 조회 시 거래 상태 표시
- [x] 거래 요청 시 이전 거래 물품 확인
- [x] 채팅방에서 거래 상세 확인 및 거래 물품 변경
- [x] 위치 재인증 로직 변경

---

### 참고

> 관련 이미지 첨부
<img width="807" height="355" alt="image" src="https://github.com/user-attachments/assets/de1fe5a1-dd5a-461f-98dc-5d91b5023059" />

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/fa26f5a8-e1aa-49bd-aca7-4ccb2dcec2ca" />
